### PR TITLE
Switch to `xz2` crate instead of `rust-lzma` for lzma encoding.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,27 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
+        feature:
+          - zstd,lzma,lz4
+        include:
+          - toolchain: stable
+            os: ubuntu-latest
+            feature: zstd
+          - toolchain: stable
+            os: ubuntu-latest
+            feature: lzma
+          - toolchain: stable
+            os: ubuntu-latest
+            feature: lz4
+          - toolchain: stable
+            os: ubuntu-latest
+            feature: zstd,lzma
+          - toolchain: stable
+            os: ubuntu-latest
+            feature: zstd,lz4
+          - toolchain: stable
+            os: ubuntu-latest
+            feature: lzma,lz4
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
@@ -35,7 +56,7 @@ jobs:
         run: cargo fmt --check
 
       - name: Test code
-        run: cargo test --verbose
+        run: cargo test --features ${{ matrix.feature }} --verbose
 
       - name: Build and run exemples
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup rust toolchain ${{ matrix.toolchain }}
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["database", "data-structures", "compression"]
 [features]
 default = ["zstd"]
 lz4 = ["dep:lz4"]
-lzma = ["dep:rust-lzma"]
+lzma = ["dep:xz2"]
 zstd = ["dep:zstd"]
 
 [dependencies]
@@ -20,7 +20,7 @@ uuid = { version = "1.4.1", features = ["v4"] }
 blake3 = "1.5.0"
 lz4 = { version = "1.24.0", optional = true }
 zstd = { version = "0.12.4", optional = true }
-rust-lzma = { version = "0.6", optional = true }
+xz2 = { version = "0.1", optional = true }
 clap = { version = "4.4.5", features = ["derive"] }
 lru = "0.11.1"
 memmap2 = "0.8.0"

--- a/src/bases/io/mod.rs
+++ b/src/bases/io/mod.rs
@@ -105,13 +105,21 @@ mod tests {
     fn create_lzma_reader(data: &[u8]) -> Option<Reader> {
         let compressed_content = {
             let compressed_content = Vec::new();
-            let mut encoder =
-                lzma::LzmaWriter::new_compressor(Cursor::new(compressed_content), 9).unwrap();
+            let mut encoder = xz2::write::XzEncoder::new_stream(
+                Cursor::new(compressed_content),
+                xz2::stream::Stream::new_lzma_encoder(
+                    &xz2::stream::LzmaOptions::new_preset(9).unwrap(),
+                )
+                .unwrap(),
+            );
             let mut incursor = Cursor::new(data);
             std::io::copy(&mut incursor, &mut encoder).unwrap();
             encoder.finish().unwrap().into_inner()
         };
-        let decoder = lzma::LzmaReader::new_decompressor(Cursor::new(compressed_content)).unwrap();
+        let decoder = xz2::read::XzDecoder::new_stream(
+            Cursor::new(compressed_content),
+            xz2::stream::Stream::new_lzma_decoder(128 * 1024 * 1024).unwrap(),
+        );
         Some(Reader::new(
             SeekableDecoder::new(decoder, Size::from(data.len())),
             End::Size(Size::from(data.len())),

--- a/src/bases/types/error.rs
+++ b/src/bases/types/error.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::string::FromUtf8Error;
 
 #[cfg(feature = "lzma")]
-use lzma::LzmaError;
+use xz2::stream::Error as lzmaError;
 
 #[derive(Debug)]
 pub struct FormatError {
@@ -97,12 +97,9 @@ impl From<FromUtf8Error> for Error {
 }
 
 #[cfg(feature = "lzma")]
-impl From<lzma::LzmaError> for Error {
-    fn from(e: LzmaError) -> Error {
-        match e {
-            LzmaError::Io(e) => Error::new(ErrorKind::Io(e)),
-            _ => FormatError::new("Lzma compression error", None).into(),
-        }
+impl From<lzmaError> for Error {
+    fn from(_e: lzmaError) -> Error {
+        FormatError::new("Lzma compression error", None).into()
     }
 }
 

--- a/src/creator/content_pack/clusterwriter.rs
+++ b/src/creator/content_pack/clusterwriter.rs
@@ -34,7 +34,10 @@ fn lzma_compress<'b>(
     stream: &'b mut dyn OutStream,
     level: u32,
 ) -> Result<&'b mut dyn OutStream> {
-    let mut encoder = lzma::LzmaWriter::new_compressor(stream, level)?;
+    let mut encoder = xz2::write::XzEncoder::new_stream(
+        stream,
+        xz2::stream::Stream::new_lzma_encoder(&xz2::stream::LzmaOptions::new_preset(level)?)?,
+    );
     for mut in_reader in data.drain(..) {
         std::io::copy(&mut in_reader, &mut encoder)?;
     }


### PR DESCRIPTION
`rust-lzma` works well but it is based on a "old" version of liblzma which in turn force a "old" version of "xz2", and so "lzma-sys" which doesn't compile on Windows.

`tar2arx` wants to use `niffler` crate which is based on `xz2` and so, `tar2arx` doesn't compile on Windows.
By moving to `xz2` (which seems better maintained/used) we fix `tar2arx` issue.