### PR TITLE
Introduce BasicCreator to simplify Jubako container creation.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ rayon = "1.8.0"
 static_assertions = "1.1.0"
 deranged = "0.3.10"
 tempfile = "3.8.0"
+bstr = "1.9.1"
 
 [dev-dependencies]
 test-case = "3.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ zerocopy = "0.7.5"
 rayon = "1.8.0"
 static_assertions = "1.1.0"
 deranged = "0.3.10"
+tempfile = "3.8.0"
 
 [dev-dependencies]
 test-case = "3.2.1"

--- a/examples/basic_creator.rs
+++ b/examples/basic_creator.rs
@@ -1,4 +1,4 @@
-use jbk::creator::{ContentAdder, EntryStoreTrait};
+use jbk::creator::EntryStoreTrait;
 use jubako as jbk;
 use jubako::creator::schema;
 use std::collections::HashMap;

--- a/examples/basic_creator.rs
+++ b/examples/basic_creator.rs
@@ -1,0 +1,160 @@
+use jbk::creator::{ContentAdder, EntryStoreTrait};
+use jubako as jbk;
+use jubako::creator::schema;
+use std::collections::HashMap;
+use std::error::Error;
+use std::sync::Arc;
+
+// This is what will allow Jubako to differenciate your format from others.
+const VENDOR_ID: jbk::VendorId = jbk::VendorId::new([01, 02, 03, 04]);
+
+// Let's use a static str as property identifier.
+// More complex application may want to use a enum instead.
+type PropertyName = &'static str;
+
+// Let's use a static str as variant identifier.
+// More complex application may want to use a enum instead.
+type VariantName = &'static str;
+
+// Our creator is really a simple one. Let's use the BasicEntry provided by jubako.
+// More complex application may want to use its own entry structure (implementing right trait)
+type EntryType = jbk::creator::BasicEntry<PropertyName, VariantName>;
+
+// We will use a EntryStore storing our entry type.
+type EntryStore = jbk::creator::EntryStore<PropertyName, VariantName, EntryType>;
+
+// Entries in a entry store have a fixed size. So strings (which have variable size) must be store elsewhere.
+// This elsewhere is a ValueStore.
+struct CustomEntryStore {
+    value_store: jbk::creator::StoreHandle,
+    entry_store: Box<EntryStore>,
+}
+
+impl CustomEntryStore {
+    fn new() -> Self {
+        // Entries have fixed sizes. We need to store variable length values in an extra store.
+        let value_store = jbk::creator::ValueStore::new_plain(None);
+
+        // Let's define our entry schema. We will have two variants (named `FirstVariant` and `SecondVariant`).
+        // Variants will have two properties in common (`AString` and `AInteger`).
+        let schema = schema::Schema::new(
+            schema::CommonProperties::new(vec![
+                schema::Property::new_array(0, value_store.clone(), "AString"), // One string, will be stored in value_store
+                schema::Property::new_uint("AInteger"),                         // A integer
+            ]),
+            vec![
+                (
+                    "FirstVariant",
+                    schema::VariantProperties::new(vec![
+                        schema::Property::new_content_address("TheContent"), // A "pointer" to a content.
+                    ]),
+                ),
+                (
+                    "SecondVariant",
+                    schema::VariantProperties::new(vec![schema::Property::new_uint("AnotherInt")]),
+                ),
+            ],
+            None,
+        );
+
+        let entry_store = Box::new(jbk::creator::EntryStore::new(schema, None));
+
+        Self {
+            value_store,
+            entry_store,
+        }
+    }
+
+    fn add_entry(
+        &mut self,
+        variant_name: Option<VariantName>,
+        values: HashMap<PropertyName, jbk::Value>,
+    ) {
+        // We have to create a EntryType from our values.
+        // To do so, we would have to preprocess the values :
+        // - add the `AString` value to the value_store and store only the idx of the value in the value store.
+        // - Transform from `jbk::Value` to `jbk::creator::Value`.
+        // - Provide a entry id.
+        // - Be sure that values match the properties declared in the schema for the given property
+        // Hopefully, `new_from_schema` does this for us.
+        // It panics if values don't match the schema/variant.
+        let entry = EntryType::new_from_schema(&self.entry_store.schema, variant_name, values);
+        self.entry_store.add_entry(entry);
+    }
+}
+
+impl EntryStoreTrait for CustomEntryStore {
+    fn finalize(self: Box<Self>, directory_pack: &mut jbk::creator::DirectoryPackCreator) {
+        // We have to populate the DirectoryPack with our data.
+
+        // First, we can add our (unique here) value store.
+        directory_pack.add_value_store(self.value_store);
+
+        // Then, add our (unique here) entry store.
+        let entry_store_id = directory_pack.add_entry_store(self.entry_store);
+
+        // We have to reference (a entry range in) our entry store to lets readers find it.
+        // This is done with a "Index"
+        directory_pack.create_index(
+            "My own index", // This is the name of our index. Reader will seach for it.
+            Default::default(),
+            0.into(), // The index is not sorted
+            entry_store_id,
+            3.into(),                         // Our index is 3 entries length
+            jubako::EntryIdx::from(0).into(), // starting at offset 0
+        );
+    }
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // Let's create a basic creator. It wrapper a ContentCreator and
+    // correctly write files, manifest packs... at finish.
+    let mut creator = jbk::creator::BasicCreator::new(
+        std::env::current_dir()?,
+        jbk::creator::ConcatMode::OneFile, // Let's put all our packs in one file
+        VENDOR_ID,
+        jbk::creator::Compression::default(),
+        Arc::new(()),
+    )?;
+
+    // The store for our entries.
+    let mut entry_store = Box::new(CustomEntryStore::new());
+
+    // Now we have "configured" our creator, let's add some content:
+    let content: Vec<u8> = "A super content prime quality for our test container".into();
+    let content_address = creator.add_content(std::io::Cursor::new(content))?;
+    entry_store.add_entry(
+        Some("FirstVariant"),
+        HashMap::from([
+            ("AString", jbk::Value::Array("Super".into())),
+            ("AInteger", jbk::Value::Unsigned(50)),
+            ("TheContent", jbk::Value::Content(content_address)),
+        ]),
+    );
+
+    entry_store.add_entry(
+        Some("SecondVariant"),
+        HashMap::from([
+            ("AString", jbk::Value::Array("Mega".into())),
+            ("AInteger", jbk::Value::Unsigned(42)),
+            ("AnotherInt", jbk::Value::Unsigned(5)),
+        ]),
+    );
+
+    entry_store.add_entry(
+        Some("SecondVariant"),
+        HashMap::from([
+            ("AString", jbk::Value::Array("Hyper".into())),
+            ("AInteger", jbk::Value::Unsigned(45)),
+            ("AnotherInt", jbk::Value::Unsigned(2)),
+        ]),
+    );
+
+    Ok(creator.finalize("test.jbk", entry_store)?)
+
+    // You have now 3 files : "test.jbkm", "test.jbkc" and "test.jbkd".
+
+    // Let's concat them in only one.
+    //jbk::concat(&["test.jbkm", "test.jbkc", "test.jbkd"], "test.jbk")?;
+    // We have now 4 files. The 4th is "test.jbk" and it contains the 3 others.
+}

--- a/examples/basic_creator.rs
+++ b/examples/basic_creator.rs
@@ -150,7 +150,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         ]),
     );
 
-    Ok(creator.finalize("test.jbk", entry_store)?)
+    Ok(creator.finalize("test.jbk", entry_store, vec![])?)
 
     // You have now 3 files : "test.jbkm", "test.jbkc" and "test.jbkd".
 

--- a/examples/simple_create.rs
+++ b/examples/simple_create.rs
@@ -1,5 +1,5 @@
 use jubako as jbk;
-use jubako::creator::schema;
+use jubako::creator::{schema, ContentAdder};
 use std::collections::HashMap;
 use std::error::Error;
 use std::fs::OpenOptions;
@@ -52,20 +52,14 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Now we have "configured" our container, let's add some content:
     let content: Vec<u8> = "A super content prime quality for our test container".into();
     let content = std::io::Cursor::new(content);
-    let content_id = content_pack.add_content(content)?;
+    let content_address = content_pack.add_content(content)?;
     entry_store.add_entry(jbk::creator::BasicEntry::new_from_schema(
         &entry_store.schema,
         Some("FirstVariant"), // Variant 0
         HashMap::from([
             ("AString", jbk::Value::Array("Super".into())),
             ("AInteger", jbk::Value::Unsigned(50)),
-            (
-                "TheContent",
-                jbk::Value::Content(jbk::ContentAddress::new(
-                    jbk::PackId::from(1), // Pack id
-                    content_id,           // Content id in the pack
-                )),
-            ),
+            ("TheContent", jbk::Value::Content(content_address)),
         ]),
     ));
 

--- a/examples/simple_create.rs
+++ b/examples/simple_create.rs
@@ -8,6 +8,7 @@ use std::fs::OpenOptions;
 const VENDOR_ID: jbk::VendorId = jbk::VendorId::new([01, 02, 03, 04]);
 
 fn main() -> Result<(), Box<dyn Error>> {
+    // We need a contentPack creator to store our content.
     let mut content_pack = jbk::creator::ContentPackCreator::new(
         "test.jbkc",
         jbk::PackId::from(1), // The pack id as referenced in the container
@@ -16,6 +17,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         jbk::creator::Compression::default(), // How to compress
     )?;
 
+    // We need a directoryPack creator to store our directory (information about the entries).
     let mut directory_pack = jbk::creator::DirectoryPackCreator::new(
         jbk::PackId::from(0),
         VENDOR_ID,
@@ -25,7 +27,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Entries have fixed sizes. We need to store variable length values in an extra store.
     let value_store = jbk::creator::ValueStore::new_plain(None);
 
-    // Our entry kind will have two variants.
+    // Let's define our entry schema. We will have two variants (named `FirstVariant` and `SecondVariant`).
+    // Variants will have two properties in common (`AString` and `AInteger`).
     let entry_def = schema::Schema::new(
         schema::CommonProperties::new(vec![
             schema::Property::new_array(0, value_store.clone(), "AString"), // One string, will be stored in value_store
@@ -49,10 +52,22 @@ fn main() -> Result<(), Box<dyn Error>> {
     // The store for our entries.
     let mut entry_store = Box::new(jbk::creator::EntryStore::new(entry_def, None));
 
-    // Now we have "configured" our container, let's add some content:
+    // Now we have "configured" our creator, let's add some entries:
+
+    // For the first entry, we have a content, we need to add it to our conten creator.
     let content: Vec<u8> = "A super content prime quality for our test container".into();
     let content = std::io::Cursor::new(content);
     let content_address = content_pack.add_content(content)?;
+
+    // Now it is added, we can add the entry itself.
+    // We have to create a Entry from our values.
+    // To do so, we would have to preprocess the values :
+    // - add the `AString` value to the value_store and store only the idx of the value in the value store.
+    // - Transform from `jbk::Value` to `jbk::creator::Value`.
+    // - Provide a entry id.
+    // - Be sure that values match the properties declared in the schema for the given property
+    // Hopefully, `new_from_schema` does this for us.
+    // It panics if values don't match the schema/variant.
     entry_store.add_entry(jbk::creator::BasicEntry::new_from_schema(
         &entry_store.schema,
         Some("FirstVariant"), // Variant 0
@@ -63,6 +78,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         ]),
     ));
 
+    // Now we add our two other entries. We don't have content in the second variant
+    // so we can directly add the entries to the entry_ store.
     entry_store.add_entry(jbk::creator::BasicEntry::new_from_schema(
         &entry_store.schema,
         Some("SecondVariant"),
@@ -83,19 +100,25 @@ fn main() -> Result<(), Box<dyn Error>> {
         ]),
     ));
 
+    // We have added all our content/entries.
+    // Time to finish the creation process.
+
+    // Add the value store and the entry store the directory.
     directory_pack.add_value_store(value_store);
     let entry_store_id = directory_pack.add_entry_store(entry_store);
 
-    // One index to access our entries.
+    // We have to reference (a entry range in) our entry store to lets readers find it.
+    // This is done with a "Index"
     directory_pack.create_index(
-        "My own index",
+        "My own index", // This is the name of our index. Reader will seach for it.
         Default::default(),
         0.into(), // The index is not sorted
         entry_store_id,
-        3.into(),                         // 3 entries
-        jubako::EntryIdx::from(0).into(), // Offset 0
+        3.into(),                         // Our index is 3 entries length
+        jubako::EntryIdx::from(0).into(), // starting at offset 0
     );
 
+    // Let's write the directory pack in "test.jbkd" file
     let mut directory_file = OpenOptions::new()
         .read(true)
         .write(true)
@@ -103,11 +126,21 @@ fn main() -> Result<(), Box<dyn Error>> {
         .truncate(true)
         .open("test.jbkd")?;
     let directory_pack_info = directory_pack.finalize(&mut directory_file)?;
+
+    // Let's finalize content pack creation.
+    // We don't care about returned file as we will not store the content pack in a container.
     let (_file, content_pack_info) = content_pack.finalize()?;
+
+    // Let's start the creation of the manifest.
+    // The manifest is the entry point to find other packs. It must list add least a directory pack
+    // and optionally some content pack.
     let mut manifest_creator =
         jbk::creator::ManifestPackCreator::new(VENDOR_ID, Default::default());
 
+    // As we don't store packs in a container, we have to indicate where to find the directory pack.
     manifest_creator.add_pack(directory_pack_info, "test.jbkd".into());
+
+    // As we don't store packs in a container, we have to indicate where to find the content pack.
     manifest_creator.add_pack(content_pack_info, "test.jbkc".into());
 
     let mut manifest_file = OpenOptions::new()
@@ -118,10 +151,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         .open("test.jbkm")?;
     manifest_creator.finalize(&mut manifest_file)?;
     // You have now 3 files : "test.jbkm", "test.jbkc" and "test.jbkd".
-
-    // Let's concat them in only one.
-    //jbk::concat(&["test.jbkm", "test.jbkc", "test.jbkd"], "test.jbk")?;
-    // We have now 4 files. The 4th is "test.jbk" and it contains the 3 others.
 
     Ok(())
 }

--- a/examples/simple_create.rs
+++ b/examples/simple_create.rs
@@ -1,5 +1,5 @@
 use jubako as jbk;
-use jubako::creator::{schema, ContentAdder};
+use jubako::creator::schema;
 use std::collections::HashMap;
 use std::error::Error;
 use std::fs::OpenOptions;

--- a/examples/simple_read.rs
+++ b/examples/simple_read.rs
@@ -4,8 +4,9 @@ use jubako as jbk;
 use std::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    // Let's read our container created in `simple_create.rs`
-    let container = jbk::reader::Container::new("test.jbkm")?; // or "test.jbkm"
+    // Let's read our container created in `simple_create.rs` or `basic_creator.rs`
+
+    let container = jbk::reader::Container::new("test.jbkm")?; // or "test.jbk" if created using basic_creator.rs
     let index = container.get_index_for_name("My own index")?;
     let builder = AnyBuilder::new(
         index.get_store(&container.get_entry_storage())?,

--- a/src/bases/types/error.rs
+++ b/src/bases/types/error.rs
@@ -96,6 +96,12 @@ impl From<FromUtf8Error> for Error {
     }
 }
 
+impl From<bstr::Utf8Error> for Error {
+    fn from(_e: bstr::Utf8Error) -> Error {
+        FormatError::new("Utf8DecodingError", None).into()
+    }
+}
+
 #[cfg(feature = "lzma")]
 impl From<lzmaError> for Error {
     fn from(_e: lzmaError) -> Error {

--- a/src/creator/basic_creator.rs
+++ b/src/creator/basic_creator.rs
@@ -1,0 +1,202 @@
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use super::{
+    content_pack::ContentAdder, AtomicOutFile, Compression, ContainerPackCreator,
+    ContentPackCreator, DirectoryPackCreator, InContainerFile, InputReader, ManifestPackCreator,
+    PackRecipient, Progress,
+};
+use crate::{bases::*, ContentAddress};
+
+/// How packs will be stored
+#[derive(Clone, Copy)]
+pub enum ConcatMode {
+    /// All packs will be stored in one file
+    OneFile,
+
+    /// Manifest and directory packs will be stored together and content pack will
+    /// be stored separatly (with a extra `.jbkc` extension).
+    TwoFiles,
+
+    /// Manifest, directory and content packs will be store separatly with respective
+    /// extensions `.jbkm`, `jbkd` and `.jbkc` added.
+    NoConcat,
+}
+
+/// EntryStore must finalizable
+pub trait EntryStoreTrait {
+    /// Finalize EntryStore creation
+    ///
+    /// Most custom entry store creator will wrap value and entry stores.
+    /// This method must add them to `directory_pack`.
+    fn finalize(self: Box<Self>, directory_pack: &mut DirectoryPackCreator);
+}
+
+/// BasicCreator provides a simplify way to create a Jubako container.
+///
+/// A Jubako container is composed of several packs.
+/// Writing them correctly in a efficient way can be difficult.
+/// BasicCreator provides a simplify API and handle most of the generic, borring part
+/// of Jubako creation.
+pub struct BasicCreator {
+    directory_pack: DirectoryPackCreator,
+    content_pack: ContentPackCreator<InContainerFile<AtomicOutFile>>,
+    concat_mode: ConcatMode,
+    vendor_id: VendorId,
+}
+
+fn new_with_extension<S: AsRef<OsStr>>(path: &Path, extension: S) -> PathBuf {
+    let new_extension = match path.extension() {
+        None => extension.as_ref().to_os_string(),
+        Some(e) => {
+            let mut e = e.to_os_string();
+            e.push(extension);
+            e
+        }
+    };
+    let mut buf = path.to_path_buf();
+    buf.set_extension(new_extension);
+    buf
+}
+
+impl BasicCreator {
+    /// Create a BasicCreator.
+    ///
+    /// Temporary files will be stored in `tempdir`. For performance reason, it is adviced
+    /// to using a tempdir in same filesystem than final files to avoid copy of file between
+    /// fs at end of creation process.
+    pub fn new<P: AsRef<Path>>(
+        outfile: P,
+        concat_mode: ConcatMode,
+        vendor_id: VendorId,
+        compression: Compression,
+        progress: Arc<dyn Progress>,
+    ) -> Result<Self> {
+        let atomic_content_pack_file = if let ConcatMode::OneFile = concat_mode {
+            AtomicOutFile::new(outfile)?
+        } else {
+            AtomicOutFile::new(new_with_extension(outfile.as_ref(), "jbkc"))?
+        };
+        // We may have only one (content) pack in the container so container may not be necessary.
+        // But let's put all in a container. It is simpler and it can simplify things if
+        // user want to concat packs later.
+        let tmp_content_pack =
+            ContainerPackCreator::from_file(atomic_content_pack_file)?.into_file()?;
+
+        let content_pack = ContentPackCreator::new_from_output_with_progress(
+            tmp_content_pack,
+            PackId::from(1),
+            vendor_id,
+            Default::default(),
+            compression,
+            progress,
+        )?;
+
+        let directory_pack =
+            DirectoryPackCreator::new(PackId::from(0), vendor_id, Default::default());
+
+        Ok(Self {
+            directory_pack,
+            content_pack,
+            concat_mode,
+            vendor_id,
+        })
+    }
+
+    /// Finalize the creation of Jubako container and create the archive as `outfile`.
+    pub fn finalize<P: AsRef<Path>>(
+        mut self,
+        outfile: P,
+        entry_store_creator: Box<dyn EntryStoreTrait>,
+    ) -> Result<()> {
+        let outfile = outfile.as_ref();
+        entry_store_creator.finalize(&mut self.directory_pack);
+
+        let (content_pack_file, content_pack_info) = self.content_pack.finalize()?;
+        let (mut container, content_locator) = {
+            let container = content_pack_file.close(content_pack_info.uuid)?;
+            match self.concat_mode {
+                ConcatMode::OneFile => {
+                    // Don't close the container as we will add new pack in it.
+                    (Some(container), vec![])
+                }
+                _ => {
+                    // We must close the container, persist it but, maybe create a new one.
+                    let container_file = container.finalize()?;
+                    let content_pack_locator = container_file.close_file()?;
+                    let new_container = if let ConcatMode::TwoFiles = self.concat_mode {
+                        // We have to create a new container creator for other packs
+
+                        let atomic_container_pack = AtomicOutFile::new(outfile)?;
+                        // We may have only one (content) pack in the container so container may not be necessary.
+                        // But let's put all in a container. It is simpler and it can simplify things if
+                        // user want to concat packs later.
+                        let tmp_container_pack =
+                            ContainerPackCreator::from_file(atomic_container_pack)?;
+                        Some(tmp_container_pack)
+                    } else {
+                        None
+                    };
+                    (new_container, content_pack_locator)
+                }
+            }
+        };
+
+        // [TODO] Write extra content_pack
+
+        let (directory_pack_info, directory_locator) = match container.take() {
+            Some(inner_container) => {
+                // Write directory pack in container
+                let mut infile = inner_container.into_file()?;
+                let directory_pack_info = self.directory_pack.finalize(&mut infile)?;
+                container = Some(infile.close(directory_pack_info.uuid)?);
+                (directory_pack_info, vec![])
+            }
+            None => {
+                // Write directory pack in its own file
+                let mut atomic_tmp_file = AtomicOutFile::new(new_with_extension(outfile, ".jbkd"))?;
+                let directory_pack_info = self.directory_pack.finalize(&mut atomic_tmp_file)?;
+                let directory_pack_locator = atomic_tmp_file.close_file()?;
+                (directory_pack_info, directory_pack_locator)
+            }
+        };
+
+        // Time to build our manifest
+        let mut manifest_creator = ManifestPackCreator::new(self.vendor_id, Default::default());
+        manifest_creator.add_pack(directory_pack_info, directory_locator);
+        manifest_creator.add_pack(content_pack_info, content_locator);
+
+        // [TODO] Add extra content_pack
+
+        match container.take() {
+            Some(inner_container) => {
+                let mut infile = inner_container.into_file()?;
+                let manifest_uuid = manifest_creator.finalize(&mut infile)?;
+                container = Some(infile.close(manifest_uuid)?);
+            }
+            None => {
+                // Write manifest in its own file
+                let mut atomic_tmp_file = AtomicOutFile::new(outfile)?;
+                manifest_creator.finalize(&mut atomic_tmp_file)?;
+                atomic_tmp_file.close_file()?;
+            }
+        }
+
+        if let Some(container) = container {
+            // We have a container not closed (and not persisted)
+            let container_file = container.finalize()?;
+            container_file.close_file()?;
+        }
+
+        Ok(())
+    }
+}
+
+impl ContentAdder for BasicCreator {
+    fn add_content<R: InputReader + 'static>(&mut self, content: R) -> Result<ContentAddress> {
+        self.content_pack.add_content(content)
+    }
+}

--- a/src/creator/basic_creator.rs
+++ b/src/creator/basic_creator.rs
@@ -203,10 +203,14 @@ impl BasicCreator {
 
         Ok(())
     }
+
+    pub fn add_content<R: InputReader + 'static>(&mut self, content: R) -> Result<ContentAddress> {
+        self.content_pack.add_content(content)
+    }
 }
 
 impl ContentAdder for BasicCreator {
     fn add_content<R: InputReader + 'static>(&mut self, content: R) -> Result<ContentAddress> {
-        self.content_pack.add_content(content)
+        self.add_content(content)
     }
 }

--- a/src/creator/content_pack/creator.rs
+++ b/src/creator/content_pack/creator.rs
@@ -200,10 +200,11 @@ impl<O: PackRecipient + 'static + ?Sized> ContentPackCreator<O> {
         content.seek(SeekFrom::Start(0))?;
         Ok(entropy <= 6.0)
     }
-}
 
-impl<O: PackRecipient + 'static> ContentAdder for ContentPackCreator<O> {
-    fn add_content<R: InputReader + 'static>(&mut self, mut content: R) -> Result<ContentAddress> {
+    pub fn add_content<R: InputReader + 'static>(
+        &mut self,
+        mut content: R,
+    ) -> Result<ContentAddress> {
         let content_size = content.size();
         self.progress.content_added(content_size);
         let should_compress = self.detect_compression(&mut content)?;
@@ -212,6 +213,12 @@ impl<O: PackRecipient + 'static> ContentAdder for ContentPackCreator<O> {
         self.content_infos.push(content_info);
         let content_id = ((self.content_infos.len() - 1) as u32).into();
         Ok(ContentAddress::new(self.pack_id, content_id))
+    }
+}
+
+impl<O: PackRecipient + 'static + ?Sized> ContentAdder for ContentPackCreator<O> {
+    fn add_content<R: InputReader + 'static>(&mut self, content: R) -> Result<ContentAddress> {
+        self.add_content(content)
     }
 }
 

--- a/src/creator/content_pack/mod.rs
+++ b/src/creator/content_pack/mod.rs
@@ -9,6 +9,8 @@ use std::collections::{hash_map::Entry, HashMap};
 use std::io::SeekFrom;
 use std::rc::Rc;
 
+use super::PackRecipient;
+
 pub trait Progress: Send + Sync {
     fn new_cluster(&self, _cluster_idx: u32, _compressed: bool) {}
     fn handle_cluster(&self, _cluster_idx: u32, _compressed: bool) {}
@@ -24,13 +26,13 @@ pub trait CacheProgress {
 
 impl CacheProgress for () {}
 
-pub struct CachedContentPackCreator<O: OutStream + 'static> {
+pub struct CachedContentPackCreator<O: PackRecipient + 'static> {
     content_pack: ContentPackCreator<O>,
     cache: HashMap<blake3::Hash, ContentIdx>,
     progress: Rc<dyn CacheProgress>,
 }
 
-impl<O: OutStream> CachedContentPackCreator<O> {
+impl<O: PackRecipient> CachedContentPackCreator<O> {
     pub fn new(content_pack: ContentPackCreator<O>, progress: Rc<dyn CacheProgress>) -> Self {
         Self {
             content_pack,

--- a/src/creator/content_pack/mod.rs
+++ b/src/creator/content_pack/mod.rs
@@ -50,10 +50,8 @@ impl<Wrapped: ContentAdder> CachedContentAdder<Wrapped> {
     pub fn into_inner(self) -> Wrapped {
         self.content_pack
     }
-}
 
-impl<Wrapper: ContentAdder> ContentAdder for CachedContentAdder<Wrapper> {
-    fn add_content<R: InputReader>(&mut self, mut reader: R) -> Result<crate::ContentAddress> {
+    pub fn add_content<R: InputReader>(&mut self, mut reader: R) -> Result<crate::ContentAddress> {
         let mut hasher = blake3::Hasher::new();
         hasher.update_reader(&mut reader)?;
         let hash = hasher.finalize();
@@ -69,5 +67,11 @@ impl<Wrapper: ContentAdder> ContentAdder for CachedContentAdder<Wrapper> {
                 Ok(*e.get())
             }
         }
+    }
+}
+
+impl<Wrapper: ContentAdder> ContentAdder for CachedContentAdder<Wrapper> {
+    fn add_content<R: InputReader>(&mut self, reader: R) -> Result<crate::ContentAddress> {
+        self.add_content(reader)
     }
 }

--- a/src/creator/content_pack/mod.rs
+++ b/src/creator/content_pack/mod.rs
@@ -2,14 +2,12 @@ mod cluster;
 mod clusterwriter;
 mod creator;
 
-use crate::bases::*;
 use crate::creator::InputReader;
+use crate::{bases::*, ContentAddress};
 pub use creator::ContentPackCreator;
 use std::collections::{hash_map::Entry, HashMap};
 use std::io::SeekFrom;
 use std::rc::Rc;
-
-use super::PackRecipient;
 
 pub trait Progress: Send + Sync {
     fn new_cluster(&self, _cluster_idx: u32, _compressed: bool) {}
@@ -26,14 +24,22 @@ pub trait CacheProgress {
 
 impl CacheProgress for () {}
 
-pub struct CachedContentPackCreator<O: PackRecipient + 'static> {
-    content_pack: ContentPackCreator<O>,
-    cache: HashMap<blake3::Hash, ContentIdx>,
+/// A trait for structure able to add content to a content pack.
+///
+/// Usefull to implement wrapper on one [ContentPackCreator]
+pub trait ContentAdder {
+    /// Add a content into a content pack.
+    fn add_content<R: InputReader>(&mut self, reader: R) -> Result<ContentAddress>;
+}
+
+pub struct CachedContentAdder<Wrapped: ContentAdder + 'static> {
+    content_pack: Wrapped,
+    cache: HashMap<blake3::Hash, ContentAddress>,
     progress: Rc<dyn CacheProgress>,
 }
 
-impl<O: PackRecipient> CachedContentPackCreator<O> {
-    pub fn new(content_pack: ContentPackCreator<O>, progress: Rc<dyn CacheProgress>) -> Self {
+impl<Wrapped: ContentAdder> CachedContentAdder<Wrapped> {
+    pub fn new(content_pack: Wrapped, progress: Rc<dyn CacheProgress>) -> Self {
         Self {
             content_pack,
             cache: Default::default(),
@@ -41,28 +47,27 @@ impl<O: PackRecipient> CachedContentPackCreator<O> {
         }
     }
 
-    pub fn add_content<R>(&mut self, mut content: R) -> Result<ContentIdx>
-    where
-        R: InputReader + 'static,
-    {
+    pub fn into_inner(self) -> Wrapped {
+        self.content_pack
+    }
+}
+
+impl<Wrapper: ContentAdder> ContentAdder for CachedContentAdder<Wrapper> {
+    fn add_content<R: InputReader>(&mut self, mut reader: R) -> Result<crate::ContentAddress> {
         let mut hasher = blake3::Hasher::new();
-        hasher.update_reader(&mut content)?;
+        hasher.update_reader(&mut reader)?;
         let hash = hasher.finalize();
-        content.seek(SeekFrom::Start(0))?;
+        reader.seek(SeekFrom::Start(0))?;
         match self.cache.entry(hash) {
             Entry::Vacant(e) => {
-                let content_idx = self.content_pack.add_content(content)?;
-                e.insert(content_idx);
-                Ok(content_idx)
+                let content_address = self.content_pack.add_content(reader)?;
+                e.insert(content_address);
+                Ok(content_address)
             }
             Entry::Occupied(e) => {
-                self.progress.cached_data(content.size());
+                self.progress.cached_data(reader.size());
                 Ok(*e.get())
             }
         }
-    }
-
-    pub fn into_inner(self) -> ContentPackCreator<O> {
-        self.content_pack
     }
 }

--- a/src/creator/mod.rs
+++ b/src/creator/mod.rs
@@ -1,3 +1,4 @@
+mod basic_creator;
 mod container_pack;
 mod content_pack;
 mod directory_pack;
@@ -6,8 +7,11 @@ mod manifest_pack;
 use crate::bases::*;
 pub use crate::bases::{FileSource, InOutStream, OutStream, Reader};
 use crate::common::{CheckInfo, CompressionType, PackKind};
+pub use basic_creator::{BasicCreator, ConcatMode, EntryStoreTrait};
 pub use container_pack::{ContainerPackCreator, InContainerFile};
-pub use content_pack::{CacheProgress, CachedContentPackCreator, ContentPackCreator, Progress};
+pub use content_pack::{
+    CacheProgress, CachedContentAdder, ContentAdder, ContentPackCreator, Progress,
+};
 pub use directory_pack::{
     schema, Array, ArrayS, BasicEntry, DirectoryPackCreator, EntryStore, EntryTrait,
     FullEntryTrait, IndexedValueStore, PlainValueStore, PropertyName, StoreHandle, Value,

--- a/src/reader/locator.rs
+++ b/src/reader/locator.rs
@@ -1,4 +1,5 @@
 use crate::bases::*;
+use bstr::ByteSlice;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use uuid::Uuid;
@@ -21,8 +22,7 @@ impl FsLocator {
 
 impl PackLocatorTrait for FsLocator {
     fn locate(&self, _uuid: Uuid, path: &[u8]) -> Result<Option<Reader>> {
-        let path = String::from_utf8_lossy(path);
-        let path = Path::new(path.as_ref());
+        let path = Path::new(path.to_path()?);
         let path = self.base_dir.join(path);
         if path.is_file() {
             Ok(Some(Reader::from(FileSource::open(path)?)))

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -13,7 +13,8 @@ pub fn concat<P: AsRef<Path>>(infiles: &[P], outfile: P) -> jbk::Result<()> {
         }
     }
 
-    container.finalize()
+    container.finalize()?;
+    Ok(())
 }
 
 pub fn open_pack<P: AsRef<Path>>(path: P) -> jbk::Result<ContainerPack> {

--- a/tests/creator_jubako.rs
+++ b/tests/creator_jubako.rs
@@ -10,7 +10,7 @@ test_suite! {
     name basic_creation;
 
     use jubako::creator;
-    use jubako::creator::{schema, ContentAdder};
+    use jubako::creator::schema;
     use jubako::Result;
     use jubako::reader::{Range, EntryTrait};
     use std::io::{Read, Seek};

--- a/tests/creator_jubako.rs
+++ b/tests/creator_jubako.rs
@@ -10,7 +10,7 @@ test_suite! {
     name basic_creation;
 
     use jubako::creator;
-    use jubako::creator::schema;
+    use jubako::creator::{schema, ContentAdder};
     use jubako::Result;
     use jubako::reader::{Range, EntryTrait};
     use std::io::{Read, Seek};

--- a/tests/creator_jubako.rs
+++ b/tests/creator_jubako.rs
@@ -86,7 +86,7 @@ test_suite! {
         }
         let (mut file, pack_info) = creator.finalize()?;
         file.rewind()?;
-        Ok((pack_info, jubako::FileSource::new(file)?.into()))
+        Ok((pack_info, jubako::FileSource::new(file.into_inner())?.into()))
     }
 
     fn create_directory_pack(value_store_kind: ValueStoreKind, entries: &Vec<TestEntry>, outfile: &Path) -> Result<(creator::PackData, jubako::Reader)> {


### PR DESCRIPTION
Jubako containers are always composed of at least 3 packs.
They always have to be created and potentially concatenated into one or two files.
And for performance reason, we also want to create the (main) content pack "in place" and not copy it into the container at end of process.

All this is pretty common in all and kind of tricky.
Let's create a `BasicCreator` handling all the boilerplate.