### PR TITLE
Perf improvement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ static_assertions = "1.1.0"
 deranged = "0.3.10"
 tempfile = "3.8.0"
 bstr = "1.9.1"
+dropout = "0.1.0"
 
 [dev-dependencies]
 test-case = "3.2.1"

--- a/examples/basic_creator.rs
+++ b/examples/basic_creator.rs
@@ -122,7 +122,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Now we have "configured" our creator, let's add some content:
     let content: Vec<u8> = "A super content prime quality for our test container".into();
-    let content_address = creator.add_content(std::io::Cursor::new(content), Default::default())?;
+    let content_address =
+        creator.add_content(Box::new(std::io::Cursor::new(content)), Default::default())?;
     entry_store.add_entry(
         Some("FirstVariant"),
         HashMap::from([

--- a/examples/basic_creator.rs
+++ b/examples/basic_creator.rs
@@ -122,7 +122,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Now we have "configured" our creator, let's add some content:
     let content: Vec<u8> = "A super content prime quality for our test container".into();
-    let content_address = creator.add_content(std::io::Cursor::new(content))?;
+    let content_address = creator.add_content(std::io::Cursor::new(content), Default::default())?;
     entry_store.add_entry(
         Some("FirstVariant"),
         HashMap::from([

--- a/examples/simple_create.rs
+++ b/examples/simple_create.rs
@@ -56,7 +56,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // For the first entry, we have a content, we need to add it to our conten creator.
     let content: Vec<u8> = "A super content prime quality for our test container".into();
-    let content = std::io::Cursor::new(content);
+    let content = Box::new(std::io::Cursor::new(content));
     let content_address = content_pack.add_content(content, Default::default())?;
 
     // Now it is added, we can add the entry itself.

--- a/examples/simple_create.rs
+++ b/examples/simple_create.rs
@@ -125,7 +125,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .create(true)
         .truncate(true)
         .open("test.jbkd")?;
-    let directory_pack_info = directory_pack.finalize(&mut directory_file)?;
+    let directory_pack_info = directory_pack.finalize()?.write(&mut directory_file)?;
 
     // Let's finalize content pack creation.
     // We don't care about returned file as we will not store the content pack in a container.

--- a/examples/simple_create.rs
+++ b/examples/simple_create.rs
@@ -57,7 +57,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // For the first entry, we have a content, we need to add it to our conten creator.
     let content: Vec<u8> = "A super content prime quality for our test container".into();
     let content = std::io::Cursor::new(content);
-    let content_address = content_pack.add_content(content)?;
+    let content_address = content_pack.add_content(content, Default::default())?;
 
     // Now it is added, we can add the entry itself.
     // We have to create a Entry from our values.

--- a/src/bases/io/file.rs
+++ b/src/bases/io/file.rs
@@ -66,7 +66,7 @@ impl Source for FileSource {
         self: Arc<Self>,
         region: Region,
     ) -> Result<(Arc<dyn MemorySource>, Region)> {
-        if region.size().into_u64() < 1024 {
+        if region.size().into_u64() < 4 * 1024 {
             let mut f = self.lock().unwrap();
             let mut buf = Vec::with_capacity(region.size().into_usize());
             f.seek(SeekFrom::Start(region.begin().into_u64()))?;

--- a/src/creator/basic_creator.rs
+++ b/src/creator/basic_creator.rs
@@ -5,9 +5,9 @@ use std::{
 };
 
 use super::{
-    content_pack::ContentAdder, AtomicOutFile, Compression, ContainerPackCreator,
-    ContentPackCreator, DirectoryPackCreator, InContainerFile, InputReader, ManifestPackCreator,
-    PackRecipient, Progress,
+    content_pack::{CompHint, ContentAdder},
+    AtomicOutFile, Compression, ContainerPackCreator, ContentPackCreator, DirectoryPackCreator,
+    InContainerFile, InputReader, ManifestPackCreator, PackRecipient, Progress,
 };
 use crate::{bases::*, ContentAddress};
 
@@ -206,13 +206,21 @@ impl BasicCreator {
         Ok(())
     }
 
-    pub fn add_content<R: InputReader + 'static>(&mut self, content: R) -> Result<ContentAddress> {
-        self.content_pack.add_content(content)
+    pub fn add_content<R: InputReader + 'static>(
+        &mut self,
+        content: R,
+        comp_hint: CompHint,
+    ) -> Result<ContentAddress> {
+        self.content_pack.add_content(content, comp_hint)
     }
 }
 
 impl ContentAdder for BasicCreator {
-    fn add_content<R: InputReader + 'static>(&mut self, content: R) -> Result<ContentAddress> {
-        self.add_content(content)
+    fn add_content<R: InputReader + 'static>(
+        &mut self,
+        content: R,
+        comp_hint: CompHint,
+    ) -> Result<ContentAddress> {
+        self.add_content(content, comp_hint)
     }
 }

--- a/src/creator/basic_creator.rs
+++ b/src/creator/basic_creator.rs
@@ -206,9 +206,9 @@ impl BasicCreator {
         Ok(())
     }
 
-    pub fn add_content<R: InputReader + 'static>(
+    pub fn add_content(
         &mut self,
-        content: R,
+        content: Box<dyn InputReader>,
         comp_hint: CompHint,
     ) -> Result<ContentAddress> {
         self.content_pack.add_content(content, comp_hint)
@@ -216,9 +216,9 @@ impl BasicCreator {
 }
 
 impl ContentAdder for BasicCreator {
-    fn add_content<R: InputReader + 'static>(
+    fn add_content(
         &mut self,
-        content: R,
+        content: Box<dyn InputReader>,
         comp_hint: CompHint,
     ) -> Result<ContentAddress> {
         self.add_content(content, comp_hint)

--- a/src/creator/container_pack.rs
+++ b/src/creator/container_pack.rs
@@ -4,7 +4,7 @@ use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::path::Path;
 
 use super::private::Sealed;
-use super::{NamedFile, PackRecipient};
+use super::{MaybeFileReader, NamedFile, PackRecipient};
 
 pub struct ContainerPackCreator<F: PackRecipient> {
     packs: Vec<PackLocator>,
@@ -110,7 +110,10 @@ impl<F: PackRecipient> Read for InContainerFile<F> {
 }
 
 impl<F: PackRecipient + std::fmt::Debug + Sync + Send> OutStream for InContainerFile<F> {
-    fn copy(&mut self, reader: Box<dyn crate::creator::InputReader>) -> IoResult<u64> {
+    fn copy(
+        &mut self,
+        reader: Box<dyn crate::creator::InputReader>,
+    ) -> IoResult<(u64, MaybeFileReader)> {
         self.file.copy(reader)
     }
 }

--- a/src/creator/content_pack/cluster.rs
+++ b/src/creator/content_pack/cluster.rs
@@ -1,5 +1,3 @@
-use std::io::Cursor;
-
 use crate::bases::*;
 use crate::common::ContentInfo;
 use crate::creator::InputReader;
@@ -43,16 +41,9 @@ impl ClusterCreator {
         self.data.is_empty()
     }
 
-    pub fn add_content(&mut self, mut content: Box<dyn InputReader>) -> Result<ContentInfo> {
+    pub fn add_content(&mut self, content: Box<dyn InputReader>) -> Result<ContentInfo> {
         assert!(self.offsets.len() < MAX_BLOBS_PER_CLUSTER);
         let content_size = content.size();
-        let content: Box<dyn InputReader> = if self.compressed || content_size < CLUSTER_SIZE {
-            let mut bytes = Vec::with_capacity(content_size.into_usize());
-            content.read_to_end(&mut bytes)?;
-            Box::new(Cursor::new(bytes))
-        } else {
-            content
-        };
         let idx = self.offsets.len() as u16;
         let new_offset = self.offsets.last().unwrap_or(&0) + content_size.into_usize();
         self.data.push(content);

--- a/src/creator/content_pack/cluster.rs
+++ b/src/creator/content_pack/cluster.rs
@@ -10,7 +10,7 @@ pub struct ClusterCreator {
     pub offsets: Vec<usize>,
 }
 
-const CLUSTER_SIZE: Size = Size::new(1024 * 1024 * 4);
+pub(crate) const CLUSTER_SIZE: Size = Size::new(1024 * 1024 * 4);
 const MAX_BLOBS_PER_CLUSTER: usize = 0xFFF;
 
 impl ClusterCreator {

--- a/src/creator/content_pack/creator.rs
+++ b/src/creator/content_pack/creator.rs
@@ -1,6 +1,6 @@
 use super::cluster::ClusterCreator;
 use super::clusterwriter::ClusterWriterProxy;
-use super::{ContentAdder, Progress};
+use super::{CompHint, ContentAdder, Progress};
 use crate::bases::*;
 use crate::common::{
     CheckInfo, ContentAddress, ContentInfo, ContentPackHeader, PackHeaderInfo, PackKind,
@@ -188,26 +188,37 @@ impl<O: PackRecipient + 'static + ?Sized> ContentPackCreator<O> {
         }
     }
 
-    fn detect_compression<R: InputReader + 'static>(&self, content: &mut R) -> Result<bool> {
+    fn detect_compression<R: InputReader + 'static>(
+        &self,
+        content: &mut R,
+        comp_hint: CompHint,
+    ) -> Result<bool> {
         if let Compression::None = self.compression {
             return Ok(false);
         }
-        let mut head = Vec::with_capacity(4 * 1024);
-        {
-            content.by_ref().take(4 * 1024).read_to_end(&mut head)?;
+        match comp_hint {
+            CompHint::Yes => Ok(true),
+            CompHint::No => Ok(false),
+            CompHint::Detect => {
+                let mut head = Vec::with_capacity(4 * 1024);
+                {
+                    content.by_ref().take(4 * 1024).read_to_end(&mut head)?;
+                }
+                let entropy = shannon_entropy(&head)?;
+                content.seek(SeekFrom::Start(0))?;
+                Ok(entropy <= 6.0)
+            }
         }
-        let entropy = shannon_entropy(&head)?;
-        content.seek(SeekFrom::Start(0))?;
-        Ok(entropy <= 6.0)
     }
 
     pub fn add_content<R: InputReader + 'static>(
         &mut self,
         mut content: R,
+        comp_hint: CompHint,
     ) -> Result<ContentAddress> {
         let content_size = content.size();
         self.progress.content_added(content_size);
-        let should_compress = self.detect_compression(&mut content)?;
+        let should_compress = self.detect_compression(&mut content, comp_hint)?;
         let cluster = self.get_open_cluster(should_compress, content_size)?;
         let content_info = cluster.add_content(content)?;
         self.content_infos.push(content_info);
@@ -217,8 +228,12 @@ impl<O: PackRecipient + 'static + ?Sized> ContentPackCreator<O> {
 }
 
 impl<O: PackRecipient + 'static + ?Sized> ContentAdder for ContentPackCreator<O> {
-    fn add_content<R: InputReader + 'static>(&mut self, content: R) -> Result<ContentAddress> {
-        self.add_content(content)
+    fn add_content<R: InputReader + 'static>(
+        &mut self,
+        content: R,
+        comp_hint: CompHint,
+    ) -> Result<ContentAddress> {
+        self.add_content(content, comp_hint)
     }
 }
 

--- a/src/creator/content_pack/mod.rs
+++ b/src/creator/content_pack/mod.rs
@@ -24,12 +24,28 @@ pub trait CacheProgress {
 
 impl CacheProgress for () {}
 
+pub enum CompHint {
+    Yes,
+    No,
+    Detect,
+}
+
+impl Default for CompHint {
+    fn default() -> Self {
+        Self::Detect
+    }
+}
+
 /// A trait for structure able to add content to a content pack.
 ///
 /// Usefull to implement wrapper on one [ContentPackCreator]
 pub trait ContentAdder {
     /// Add a content into a content pack.
-    fn add_content<R: InputReader>(&mut self, reader: R) -> Result<ContentAddress>;
+    fn add_content<R: InputReader>(
+        &mut self,
+        reader: R,
+        comp_hint: CompHint,
+    ) -> Result<ContentAddress>;
 }
 
 pub struct CachedContentAdder<Wrapped: ContentAdder + 'static> {
@@ -51,14 +67,18 @@ impl<Wrapped: ContentAdder> CachedContentAdder<Wrapped> {
         self.content_pack
     }
 
-    pub fn add_content<R: InputReader>(&mut self, mut reader: R) -> Result<crate::ContentAddress> {
+    pub fn add_content<R: InputReader>(
+        &mut self,
+        mut reader: R,
+        comp_hint: CompHint,
+    ) -> Result<crate::ContentAddress> {
         let mut hasher = blake3::Hasher::new();
         hasher.update_reader(&mut reader)?;
         let hash = hasher.finalize();
         reader.seek(SeekFrom::Start(0))?;
         match self.cache.entry(hash) {
             Entry::Vacant(e) => {
-                let content_address = self.content_pack.add_content(reader)?;
+                let content_address = self.content_pack.add_content(reader, comp_hint)?;
                 e.insert(content_address);
                 Ok(content_address)
             }
@@ -71,7 +91,11 @@ impl<Wrapped: ContentAdder> CachedContentAdder<Wrapped> {
 }
 
 impl<Wrapper: ContentAdder> ContentAdder for CachedContentAdder<Wrapper> {
-    fn add_content<R: InputReader>(&mut self, reader: R) -> Result<crate::ContentAddress> {
-        self.add_content(reader)
+    fn add_content<R: InputReader>(
+        &mut self,
+        reader: R,
+        comp_hint: CompHint,
+    ) -> Result<crate::ContentAddress> {
+        self.add_content(reader, comp_hint)
     }
 }

--- a/src/creator/directory_pack/value_store.rs
+++ b/src/creator/directory_pack/value_store.rs
@@ -131,7 +131,7 @@ impl ValueStore {
     }
 
     pub fn new_indexed() -> StoreHandle {
-        Self::Indexed(IndexedValueStore(BaseValueStore::new(None))).into()
+        Self::Indexed(IndexedValueStore(BaseValueStore::new(Some(0)))).into()
     }
 
     pub fn finalize(&mut self, idx: ValueStoreIdx) {

--- a/src/creator/mod.rs
+++ b/src/creator/mod.rs
@@ -57,7 +57,7 @@ pub struct PackData {
 
 pub enum MaybeFileReader {
     Yes(std::io::Take<std::fs::File>),
-    No(Box<dyn Read>),
+    No(Box<dyn Read + Send>),
 }
 
 pub trait InputReader: Read + Seek + Send + 'static {
@@ -280,7 +280,10 @@ impl io::Read for NamedFile {
 }
 
 impl OutStream for NamedFile {
-    fn copy(&mut self, reader: Box<dyn crate::creator::InputReader>) -> IoResult<u64> {
+    fn copy(
+        &mut self,
+        reader: Box<dyn crate::creator::InputReader>,
+    ) -> IoResult<(u64, MaybeFileReader)> {
         self.file.copy(reader)
     }
 }
@@ -333,7 +336,10 @@ impl io::Read for AtomicOutFile {
 }
 
 impl OutStream for AtomicOutFile {
-    fn copy(&mut self, reader: Box<dyn crate::creator::InputReader>) -> IoResult<u64> {
+    fn copy(
+        &mut self,
+        reader: Box<dyn crate::creator::InputReader>,
+    ) -> IoResult<(u64, MaybeFileReader)> {
         self.temp_file.as_file_mut().copy(reader)
     }
 }

--- a/src/creator/mod.rs
+++ b/src/creator/mod.rs
@@ -10,7 +10,7 @@ use crate::common::{CheckInfo, CompressionType, PackKind};
 pub use basic_creator::{BasicCreator, ConcatMode, EntryStoreTrait};
 pub use container_pack::{ContainerPackCreator, InContainerFile};
 pub use content_pack::{
-    CacheProgress, CachedContentAdder, ContentAdder, ContentPackCreator, Progress,
+    CacheProgress, CachedContentAdder, CompHint, ContentAdder, ContentPackCreator, Progress,
 };
 pub use directory_pack::{
     schema, Array, ArrayS, BasicEntry, DirectoryPackCreator, EntryStore, EntryTrait,

--- a/tests/creator_jubako.rs
+++ b/tests/creator_jubako.rs
@@ -82,7 +82,7 @@ test_suite! {
         for entry in entries {
             let content = entry.content.clone();
             let content = std::io::Cursor::new(content);
-            creator.add_content(content)?;
+            creator.add_content(content, Default::default())?;
         }
         let (mut file, pack_info) = creator.finalize()?;
         file.rewind()?;

--- a/tests/creator_jubako.rs
+++ b/tests/creator_jubako.rs
@@ -130,7 +130,7 @@ test_suite! {
                 .create(true)
                 .truncate(true)
                 .open(outfile)?;
-        let pack_info = creator.finalize(&mut directory_file).unwrap();
+        let pack_info = creator.finalize()?.write(&mut directory_file).unwrap();
         directory_file.rewind().unwrap();
         Ok((pack_info, jubako::FileSource::new(directory_file).unwrap().into()))
     }

--- a/tests/creator_jubako.rs
+++ b/tests/creator_jubako.rs
@@ -81,7 +81,7 @@ test_suite! {
         )?;
         for entry in entries {
             let content = entry.content.clone();
-            let content = std::io::Cursor::new(content);
+            let content = Box::new(std::io::Cursor::new(content));
             creator.add_content(content, Default::default())?;
         }
         let (mut file, pack_info) = creator.finalize()?;


### PR DESCRIPTION
Most improvement are for the creation side. Most notably:
- Reduce copy of data.
- Drop (potentially big) user reader in a separated thread.
- Use can specify if content must be compressed or not (so we don't have to read it to detect that)
- Better parallelization.