### PR TITLE
Do not mmap with `MADV_POPULATE_READ`.

### DIFF
--- a/src/bases/io/file.rs
+++ b/src/bases/io/file.rs
@@ -122,8 +122,6 @@ impl Source for FileSource {
                 .len(full_size.into_usize())
                 .populate();
             let mmap = unsafe { mmap_options.map(self.source.lock().unwrap().get_ref())? };
-            #[cfg(target_os = "linux")]
-            mmap.advise(Advice::populate_read())?;
             #[cfg(unix)]
             mmap.advise(Advice::will_need())?;
             if let BlockCheck::Crc32 = block_check {


### PR DESCRIPTION
`MADV_POPULATE_READ` is a bit too strong for what we need. It is a "strong" advice to kernel to populate the page (and so avoid page fault later) and it returns an error if kernel haven't succeed to populate correctly.
This is made when application *want* the pages read. Not for performance hint to boost next read.

We already have the `populate()` and `will_need()` advice/option.

See https://github.com/jubako/arx/issues/41