### PR TITLE
Do not fail when trying to check to big block on 32 bits

### DIFF
--- a/src/bases/io/file.rs
+++ b/src/bases/io/file.rs
@@ -57,7 +57,7 @@ fn move_to_memory(region: Region) -> bool {
             s.parse::<usize>()
                 .expect(&format!("{s} should be a parsing size."))
         })
-        .unwrap_or(0xFFFF);
+        .unwrap_or(0xFFFFFF);
     region.size() <= Size::new(max_memory_block_size as u64)
 }
 

--- a/src/bases/io/file.rs
+++ b/src/bases/io/file.rs
@@ -52,7 +52,13 @@ const fn move_to_memory(_region: Region) -> bool {
 #[cfg(target_pointer_width = "32")]
 #[inline]
 fn move_to_memory(region: Region) -> bool {
-    region.size() <= Size::new(0xFFFF)
+    let max_memory_block_size = option_env!("JBK_MAX_MEMORY_BLOC")
+        .map(|s| {
+            s.parse::<usize>()
+                .expect(&format!("{s} should be a parsing size."))
+        })
+        .unwrap_or(0xFFFF);
+    region.size() <= Size::new(max_memory_block_size as u64)
 }
 
 impl Source for FileSource {

--- a/src/bases/io/file.rs
+++ b/src/bases/io/file.rs
@@ -1,4 +1,5 @@
 use crate::bases::*;
+use log::warn;
 #[cfg(unix)]
 use memmap2::Advice;
 use memmap2::MmapOptions;
@@ -94,7 +95,7 @@ impl Source for FileSource {
     ) -> Result<(Arc<dyn Source>, Region)> {
         if !move_to_memory(region) || !in_memory {
             if let BlockCheck::Crc32 = block_check {
-                unimplemented!("Block of not memory block is not implemented");
+                warn!("Check of not memory block is not implemented");
             }
             return Ok((self, region));
         }


### PR DESCRIPTION
On 32 bits, we don't load in memory block which are too big.
But in the same time, we were failing when trying to check block which are not in memory.

So:
- Print a warning instead of panic if trying to check a non memory block
- Extend the size of the max memory block to 16MiB