### PR TITLE
Add missing size/offset methods to ByteStream

### DIFF
--- a/src/bases/types/offset.rs
+++ b/src/bases/types/offset.rs
@@ -21,12 +21,6 @@ impl Offset {
         self.0
     }
 
-    #[cfg(target_pointer_width = "64")]
-    #[inline]
-    pub fn into_usize(self) -> usize {
-        self.0 as usize
-    }
-
     #[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
     #[inline]
     pub fn force_into_usize(self) -> usize {

--- a/src/bases/types/size.rs
+++ b/src/bases/types/size.rs
@@ -23,12 +23,6 @@ impl Size {
         self.0
     }
 
-    #[cfg(target_pointer_width = "64")]
-    #[inline]
-    pub const fn into_usize(self) -> usize {
-        self.0 as usize
-    }
-
     pub fn is_zero(&self) -> bool {
         self.0 == 0
     }

--- a/src/reader/byte_stream.rs
+++ b/src/reader/byte_stream.rs
@@ -22,6 +22,21 @@ impl ByteStream {
             offset,
         }
     }
+
+    /// The size of the data left to be read
+    pub fn size_left(&self) -> u64 {
+        (self.region.end() - self.offset).into_u64()
+    }
+
+    /// The full size of the ByteStream
+    pub fn size(&self) -> u64 {
+        self.region.size().into_u64()
+    }
+
+    /// The current offset in the ByteStream
+    pub fn offset(&self) -> u64 {
+        (self.offset - self.region.begin()).into_u64()
+    }
 }
 
 impl Read for ByteStream {


### PR DESCRIPTION
This is needed to let user know how much they can read.