### PR TITLE
Correctly fetch tags for release.

### DIFF
--- a/.github/workflows/pre_release.yml
+++ b/.github/workflows/pre_release.yml
@@ -64,7 +64,11 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        fetch-tags: true
+        fetch-depth: 0
+
+    - name: Fetch tags (see actions/checkout#1467)
+      run: |
+        git fetch --tags
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-tags: true
+          fetch-depth: 0
+
+      - name: Fetch tags (see actions/checkout#1467)
+        run: |
+          git fetch --tags
 
       - name: Publish
         env:


### PR DESCRIPTION
This is a workaround to actions/checkout#1467