### PR TITLE
Do not fail to get git_version if not on a git repository.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 name = "jubako"
 description = "The reference implementation of the Jubako container format"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Matthieu Gautier <mgautier@kymeria.fr>"]
 repository = "https://github.com/jubako/jubako"
 license = "MIT"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# Jubako 0.3.3
+
+- Fix compilation of jbk tools when installed from `crates.io` registry.
+
 # Jubako 0.3.2
 
 - Remove `into_usize` methods from `Offset` and `Size`.

--- a/src/bin/jbk/main.rs
+++ b/src/bin/jbk/main.rs
@@ -6,9 +6,14 @@ mod locate;
 use clap::Parser;
 
 const VERSION: &str = const_format::formatcp!(
-    "{} (git:{})",
+    "{}{}",
     clap::crate_version!(),
-    git_version::git_version!(args = ["--dirty=*", "--tags", "--always"])
+    git_version::git_version!(
+        args = ["--dirty=*", "--tags", "--always"],
+        fallback = "",
+        prefix = " (git:",
+        suffix = ")"
+    )
 );
 
 #[derive(Parser)]


### PR DESCRIPTION
When installing from crates.io (cargo install) we are not in a git repository.
We MUST be able to compile anyway.