### PR TITLE
Refactor Error  types.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ zerocopy = "0.7.5"
 rayon = "1.8.0"
 deranged = "0.3.10"
 tempfile = "3.8.0"
-bstr = "1.9.1"
 dropout = "0.1.0"
 serde = { version = "1.0.197", features = ["derive", "rc"], optional = true }
 serde_json = { version = "1.0.114", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ pathdiff = "0.2.1"
 spmc = "0.3.0"
 log = "0.4.20"
 fxhash = "0.2.1"
-zerocopy = "0.7.5"
+zerocopy = { version = "0.7.5", default-features = false, features = ["byteorder"] }
 rayon = "1.8.0"
 deranged = "0.3.10"
 tempfile = "3.8.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ graphex = { version = "0.2.0", optional = true }
 yansi = { version = "1.0.0", features = ["detect-tty"], optional = true }
 const_format = { version = "0.2.33", optional = true }
 git-version = { version = "0.3.9", optional = true }
+thiserror = "2.0.9"
 
 [dev-dependencies]
 test-case = "3.2.1"

--- a/examples/custom_read.rs
+++ b/examples/custom_read.rs
@@ -135,15 +135,10 @@ fn main() -> Result<(), Box<dyn Error>> {
             // Let's print the content on stdout
             let reader = container
                 .get_bytes(entry.value2)?
-                .expect("value2 has a valid packid")
+                .and_then(|m| m.transpose())
+                .expect("value2 should be valid")
                 .unwrap();
-            std::io::copy(
-                &mut reader
-                    .as_ref()
-                    .expect("value2 has a valid entry id")
-                    .stream(),
-                &mut std::io::stdout().lock(),
-            )?;
+            std::io::copy(&mut reader.stream(), &mut std::io::stdout().lock())?;
         } else {
             panic!("We should have variant0")
         }

--- a/examples/custom_read.rs
+++ b/examples/custom_read.rs
@@ -48,14 +48,18 @@ fn create_builder(
         names,
     } = layout.variant_part.as_ref().unwrap();
     assert_eq!(variants.len(), 2);
-    let value0 = (&layout.common["AString"], value_storage).try_into()?;
-    let value1 = (&layout.common["AInteger"], value_storage).try_into()?;
-    let variant0_value2 = (&variants[names["FirstVariant"] as usize]["TheContent"]).try_into()?;
-    let variant1_value2 = (
-        &variants[names["SecondVariant"] as usize]["AnotherInt"],
-        value_storage,
-    )
-        .try_into()?;
+    let value0 = layout.common["AString"]
+        .as_builder(value_storage)?
+        .expect("Layout proprety should match ArrayProperty");
+    let value1 = layout.common["AInteger"]
+        .as_builder(value_storage)?
+        .expect("Layout proprety should match IntProperty");
+    let variant0_value2 = variants[names["FirstVariant"] as usize]["TheContent"]
+        .as_builder(value_storage)?
+        .expect("Layout proprety should match ContentProperty");
+    let variant1_value2 = variants[names["SecondVariant"] as usize]["AnotherInt"]
+        .as_builder(value_storage)?
+        .expect("Layout proprety should match IntProperty");
     let variant_id = jbk::reader::builder::VariantIdProperty::new(*variant_id_offset);
     Ok(Builder {
         store,

--- a/examples/custom_read.rs
+++ b/examples/custom_read.rs
@@ -74,6 +74,7 @@ fn create_builder(
 // This is where we build our entry
 impl jbk::reader::builder::BuilderTrait for Builder {
     type Entry = Entry;
+    type Error = jbk::Error;
 
     fn create_entry(&self, idx: jbk::EntryIdx) -> jbk::Result<Option<Self::Entry>> {
         // With this, we can read the bytes corresponding to our entry in the container.

--- a/examples/custom_read.rs
+++ b/examples/custom_read.rs
@@ -104,7 +104,7 @@ impl jbk::reader::builder::BuilderTrait for Builder {
                     value2,
                 }))
             }
-            _ => Err("Unknown variant".into()),
+            _ => Err(jbk::Error::notfound("Unknown variant")),
         }
     }
 }

--- a/examples/custom_read.rs
+++ b/examples/custom_read.rs
@@ -133,9 +133,15 @@ fn main() -> Result<(), Box<dyn Error>> {
             assert_eq!(entry.value0, Vec::from("Super"));
             assert_eq!(entry.value1, 50);
             // Let's print the content on stdout
-            let reader = container.get_bytes(entry.value2)?;
+            let reader = container
+                .get_bytes(entry.value2)?
+                .expect("value2 has a valid packid")
+                .unwrap();
             std::io::copy(
-                &mut reader.as_ref().unwrap().stream(),
+                &mut reader
+                    .as_ref()
+                    .expect("value2 has a valid entry id")
+                    .stream(),
                 &mut std::io::stdout().lock(),
             )?;
         } else {

--- a/examples/simple_read.rs
+++ b/examples/simple_read.rs
@@ -30,14 +30,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         // Let's print the content on stdout
         let region = container
             .get_bytes(content_address)?
-            .expect("content_address has a valid pack_id")
+            .and_then(|m| m.transpose())
+            .expect("content_address should be valid")
             .unwrap();
-        std::io::copy(
-            &mut region
-                .expect("content_address has a valid content_id")
-                .stream(),
-            &mut std::io::stdout().lock(),
-        )?;
+        std::io::copy(&mut region.stream(), &mut std::io::stdout().lock())?;
     }
 
     {

--- a/examples/simple_read.rs
+++ b/examples/simple_read.rs
@@ -16,9 +16,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     {
         let entry = index.get_entry(&builder, 0.into())?;
         assert_eq!(entry.get_variant_id().unwrap(), Some(0.into())); // We correctly have variant 0
-        assert_eq!(entry.get_value("AString")?.as_vec()?, Vec::from("Super"));
-        assert_eq!(entry.get_value("AInteger")?.as_unsigned(), 50);
-        let value_2 = entry.get_value("TheContent")?;
+        assert_eq!(
+            entry.get_value("AString")?.unwrap().as_vec()?,
+            Vec::from("Super")
+        );
+        assert_eq!(entry.get_value("AInteger")?.unwrap().as_unsigned(), 50);
+        let value_2 = entry.get_value("TheContent")?.unwrap();
         let content_address = value_2.as_content();
         // Let's print the content on stdout
         let region = container.get_bytes(content_address)?;
@@ -28,17 +31,23 @@ fn main() -> Result<(), Box<dyn Error>> {
     {
         let entry = index.get_entry(&builder, 1.into())?;
         assert_eq!(entry.get_variant_id().unwrap(), Some(1.into()));
-        assert_eq!(entry.get_value("AString")?.as_vec()?, Vec::from("Mega"));
-        assert_eq!(entry.get_value("AInteger")?.as_unsigned(), 42);
-        assert_eq!(entry.get_value("AnotherInt")?.as_unsigned(), 5);
+        assert_eq!(
+            entry.get_value("AString")?.unwrap().as_vec()?,
+            Vec::from("Mega")
+        );
+        assert_eq!(entry.get_value("AInteger")?.unwrap().as_unsigned(), 42);
+        assert_eq!(entry.get_value("AnotherInt")?.unwrap().as_unsigned(), 5);
     }
 
     {
         let entry = index.get_entry(&builder, 2.into())?;
         assert_eq!(entry.get_variant_id().unwrap(), Some(1.into()));
-        assert_eq!(entry.get_value("AString")?.as_vec()?, Vec::from("Hyper"));
-        assert_eq!(entry.get_value("AInteger")?.as_unsigned(), 45);
-        assert_eq!(entry.get_value("AnotherInt")?.as_unsigned(), 2);
+        assert_eq!(
+            entry.get_value("AString")?.unwrap().as_vec()?,
+            Vec::from("Hyper")
+        );
+        assert_eq!(entry.get_value("AInteger")?.unwrap().as_unsigned(), 45);
+        assert_eq!(entry.get_value("AnotherInt")?.unwrap().as_unsigned(), 2);
     }
 
     Ok(())

--- a/examples/simple_read.rs
+++ b/examples/simple_read.rs
@@ -7,14 +7,18 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Let's read our container created in `simple_create.rs` or `basic_creator.rs`
 
     let container = jbk::reader::Container::new("test.jbkm")?; // or "test.jbk" if created using basic_creator.rs
-    let index = container.get_index_for_name("My own index")?;
+    let index = container
+        .get_index_for_name("My own index")?
+        .expect("'My own index' should be in the container");
     let builder = AnyBuilder::new(
         index.get_store(container.get_entry_storage())?,
         container.get_value_storage().as_ref(),
     )?;
 
     {
-        let entry = index.get_entry(&builder, 0.into())?;
+        let entry = index
+            .get_entry(&builder, 0.into())?
+            .expect("We have the entry 0");
         assert_eq!(entry.get_variant_id().unwrap(), Some(0.into())); // We correctly have variant 0
         assert_eq!(
             entry.get_value("AString")?.unwrap().as_vec()?,
@@ -29,7 +33,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     {
-        let entry = index.get_entry(&builder, 1.into())?;
+        let entry = index
+            .get_entry(&builder, 1.into())?
+            .expect("We have the entry 1");
         assert_eq!(entry.get_variant_id().unwrap(), Some(1.into()));
         assert_eq!(
             entry.get_value("AString")?.unwrap().as_vec()?,
@@ -40,7 +46,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     {
-        let entry = index.get_entry(&builder, 2.into())?;
+        let entry = index
+            .get_entry(&builder, 2.into())?
+            .expect("We have the entry 2");
+
         assert_eq!(entry.get_variant_id().unwrap(), Some(1.into()));
         assert_eq!(
             entry.get_value("AString")?.unwrap().as_vec()?,

--- a/examples/simple_read.rs
+++ b/examples/simple_read.rs
@@ -28,8 +28,16 @@ fn main() -> Result<(), Box<dyn Error>> {
         let value_2 = entry.get_value("TheContent")?.unwrap();
         let content_address = value_2.as_content();
         // Let's print the content on stdout
-        let region = container.get_bytes(content_address)?;
-        std::io::copy(&mut region.unwrap().stream(), &mut std::io::stdout().lock())?;
+        let region = container
+            .get_bytes(content_address)?
+            .expect("content_address has a valid pack_id")
+            .unwrap();
+        std::io::copy(
+            &mut region
+                .expect("content_address has a valid content_id")
+                .stream(),
+            &mut std::io::stdout().lock(),
+        )?;
     }
 
     {

--- a/src/bases/block.rs
+++ b/src/bases/block.rs
@@ -26,7 +26,11 @@ pub(crate) fn assert_slice_crc(buf: &[u8]) -> Result<()> {
     let expected_checksum = BE::read_u32(&buf[data_size..]);
     if checksum != expected_checksum {
         let found_checksum = checksum.to_be_bytes();
-        return Err(Error::corrupted(buf.to_vec(), found_checksum));
+        return Err(CorruptedFile {
+            buf: buf.to_vec(),
+            found_checksum,
+        }
+        .into());
     }
     Ok(())
 }

--- a/src/bases/block.rs
+++ b/src/bases/block.rs
@@ -26,9 +26,7 @@ pub(crate) fn assert_slice_crc(buf: &[u8]) -> Result<()> {
     let expected_checksum = BE::read_u32(&buf[data_size..]);
     if checksum != expected_checksum {
         let found_checksum = checksum.to_be_bytes();
-        return Err(format_error!(&format!(
-            "Not a valid checksum : {buf:X?}. Found is {found_checksum:X?}"
-        )));
+        return Err(Error::corrupted(buf.to_vec(), found_checksum));
     }
     Ok(())
 }

--- a/src/bases/cache.rs
+++ b/src/bases/cache.rs
@@ -1,10 +1,10 @@
-use super::types::*;
 use std::sync::{Arc, OnceLock};
 
 pub(crate) trait CachableSource<Value> {
+    type Error;
     type Idx: Into<usize> + Copy;
     fn get_len(&self) -> usize;
-    fn get_value(&self, id: Self::Idx) -> Result<Arc<Value>>;
+    fn get_value(&self, id: Self::Idx) -> Result<Arc<Value>, Self::Error>;
 }
 
 pub(crate) struct VecCache<Value, Source>
@@ -25,7 +25,7 @@ where
         Self { source, values }
     }
 
-    pub fn get(&self, index: Source::Idx) -> Result<&Arc<Value>> {
+    pub fn get(&self, index: Source::Idx) -> Result<&Arc<Value>, Source::Error> {
         let cache_slot = &self.values[index.into()];
         if cache_slot.get().is_none() {
             let new_value = self.source.get_value(index)?;

--- a/src/bases/io/buffer.rs
+++ b/src/bases/io/buffer.rs
@@ -23,7 +23,9 @@ where
         let e = o + buf.len();
         let our_size = self.as_ref().len();
         if e > our_size {
-            return Err(format!("Out of slice. {e} ({o}) > {our_size}").into());
+            return Err(format_error!(format!(
+                "Out of slice. {e} ({o}) > {our_size}"
+            )));
         }
         buf.copy_from_slice(&self.as_ref()[o..e]);
         Ok(())

--- a/src/bases/io/buffer.rs
+++ b/src/bases/io/buffer.rs
@@ -9,23 +9,21 @@ where
     fn size(&self) -> Size {
         self.as_ref().len().into()
     }
-    fn read(&self, offset: Offset, buf: &mut [u8]) -> Result<usize> {
+    fn read(&self, offset: Offset, buf: &mut [u8]) -> std::io::Result<usize> {
         let o = offset.force_into_usize();
         let mut slice = &self.as_ref()[o..];
-        match Read::read(&mut slice, buf) {
-            Err(e) => Err(e.into()),
-            Ok(v) => Ok(v),
-        }
+        Read::read(&mut slice, buf)
     }
 
-    fn read_exact(&self, offset: Offset, buf: &mut [u8]) -> Result<()> {
+    fn read_exact(&self, offset: Offset, buf: &mut [u8]) -> std::io::Result<()> {
         let o = offset.force_into_usize();
         let e = o + buf.len();
         let our_size = self.as_ref().len();
         if e > our_size {
-            return Err(format_error!(format!(
-                "Out of slice. {e} ({o}) > {our_size}"
-            )));
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                format!("Out of slice. {e} ({o}) > {our_size}"),
+            ));
         }
         buf.copy_from_slice(&self.as_ref()[o..e]);
         Ok(())

--- a/src/bases/io/compression.rs
+++ b/src/bases/io/compression.rs
@@ -175,7 +175,7 @@ impl Source for SeekableDecoder {
         let o = offset.force_into_usize();
         let end = o + buf.len();
         if end > self.buffer.total_size() {
-            return Err(String::from("Out of slice").into());
+            return Err(format_error!("Out of slice"));
         }
         self.decode_to(end);
         let slice = self.decoded_slice();
@@ -189,7 +189,11 @@ impl Source for SeekableDecoder {
             unreachable!()
         }
         if !region.end().is_valid(self.size()) {
-            return Err(format!("Out of slice. {} > {}", region.end(), self.size()).into());
+            return Err(format_error!(format!(
+                "Out of slice. {} > {}",
+                region.end(),
+                self.size()
+            )));
         }
         self.decode_to(region.end().force_into_usize());
         Ok(Cow::Borrowed(

--- a/src/bases/io/file.rs
+++ b/src/bases/io/file.rs
@@ -18,13 +18,13 @@ pub struct FileSource {
 }
 
 impl FileSource {
-    pub fn open<P: AsRef<std::path::Path>>(path: P) -> Result<Self> {
+    pub fn open<P: AsRef<std::path::Path>>(path: P) -> std::io::Result<Self> {
         let mut s = Self::new(std::fs::File::open(&path)?)?;
         s.path = path.as_ref().into();
         Ok(s)
     }
 
-    pub fn new(mut source: File) -> Result<Self> {
+    pub fn new(mut source: File) -> std::io::Result<Self> {
         let len = source.seek(SeekFrom::End(0))?;
         source.seek(SeekFrom::Start(0))?;
         let source = io::BufReader::with_capacity(1024, source);
@@ -65,22 +65,18 @@ impl Source for FileSource {
     fn size(&self) -> Size {
         (self.len).into()
     }
-    fn read(&self, offset: Offset, buf: &mut [u8]) -> Result<usize> {
+    fn read(&self, offset: Offset, buf: &mut [u8]) -> std::io::Result<usize> {
         let mut f = self.lock().unwrap();
+        // TODO: Use `read_at`/`seek_read`
         f.seek(SeekFrom::Start(offset.into_u64()))?;
-        match f.read(buf) {
-            Err(e) => Err(e.into()),
-            Ok(v) => Ok(v),
-        }
+        f.read(buf)
     }
 
-    fn read_exact(&self, offset: Offset, buf: &mut [u8]) -> Result<()> {
+    fn read_exact(&self, offset: Offset, buf: &mut [u8]) -> std::io::Result<()> {
         let mut f = self.lock().unwrap();
+        // TODO: Use `read_at`/`seek_read`
         f.seek(SeekFrom::Start(offset.into_u64()))?;
-        match f.read_exact(buf) {
-            Err(e) => Err(e.into()),
-            Ok(v) => Ok(v),
-        }
+        f.read_exact(buf)
     }
 
     fn get_slice(&self, region: ARegion, block_check: BlockCheck) -> Result<Cow<[u8]>> {

--- a/src/bases/io/mod.rs
+++ b/src/bases/io/mod.rs
@@ -14,8 +14,8 @@ use super::BlockCheck;
 
 pub(crate) trait Source: Sync + Send {
     fn size(&self) -> Size;
-    fn read_exact(&self, offset: Offset, buf: &mut [u8]) -> Result<()>;
-    fn read(&self, offset: Offset, buf: &mut [u8]) -> Result<usize>;
+    fn read_exact(&self, offset: Offset, buf: &mut [u8]) -> std::io::Result<()>;
+    fn read(&self, offset: Offset, buf: &mut [u8]) -> std::io::Result<usize>;
     fn get_slice(&self, region: ARegion, block_check: BlockCheck) -> Result<Cow<[u8]>>;
 
     fn cut(

--- a/src/bases/parsing.rs
+++ b/src/bases/parsing.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use zerocopy::{ByteOrder, LE};
 
-use super::{ByteSize, FormatError, Offset, Result};
+use super::{ByteSize, Offset, Result};
 
 /// A Parser is something parsing data from a [u8]
 pub trait Parser {
@@ -54,7 +54,7 @@ pub trait RandomParser {
 
     fn create_parser(&self, offset: Offset) -> Result<Self::Parser<'_>>;
     fn read_slice(&self, offset: Offset, size: usize) -> Result<Cow<[u8]>>;
-    fn read_data(&self, offset: Offset, buf: &mut [u8]) -> Result<()>;
+    fn read_data(&self, offset: Offset, buf: &mut [u8]) -> std::io::Result<()>;
 
     fn global_offset(&self) -> Offset;
     fn read_u8(&self, offset: Offset) -> Result<u8> {

--- a/src/bases/parsing.rs
+++ b/src/bases/parsing.rs
@@ -2,9 +2,7 @@ use std::borrow::Cow;
 
 use zerocopy::{ByteOrder, LE};
 
-use super::{Offset, Result};
-
-use super::ByteSize;
+use super::{ByteSize, FormatError, Offset, Result};
 
 /// A Parser is something parsing data from a [u8]
 pub trait Parser {
@@ -131,12 +129,11 @@ impl<'a> SliceParser<'a> {
 impl<'a> Parser for SliceParser<'a> {
     fn read_slice(&mut self, size: usize) -> Result<Cow<[u8]>> {
         if self.slice.len() < size + self.offset {
-            return Err(format!(
+            return Err(format_error!(format!(
                 "Out of slice. {size}({}) > {}",
                 self.offset,
                 self.slice.len()
-            )
-            .into());
+            )));
         }
         let slice = &self.slice[self.offset..self.offset + size];
         self.offset += size;
@@ -145,13 +142,12 @@ impl<'a> Parser for SliceParser<'a> {
 
     fn read_data(&mut self, buf: &mut [u8]) -> Result<()> {
         if self.slice.len() < buf.len() + self.offset {
-            return Err(format!(
+            return Err(format_error!(format!(
                 "Out of slice. {}({}) > {}",
                 buf.len(),
                 self.offset,
                 self.slice.len()
-            )
-            .into());
+            )));
         }
         buf.copy_from_slice(&self.slice[self.offset..self.offset + buf.len()]);
         self.offset += buf.len();
@@ -160,12 +156,11 @@ impl<'a> Parser for SliceParser<'a> {
 
     fn skip(&mut self, size: usize) -> Result<()> {
         if self.slice.len() < size + self.offset {
-            return Err(format!(
+            return Err(format_error!(format!(
                 "Out of slice. {size}({}) > {}",
                 self.offset,
                 self.slice.len()
-            )
-            .into());
+            )));
         }
         self.offset += size;
         Ok(())

--- a/src/bases/prop_type.rs
+++ b/src/bases/prop_type.rs
@@ -1,3 +1,5 @@
+use crate::bases::{Error, Result};
+
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[repr(u8)]
 pub(crate) enum PropType {
@@ -12,8 +14,8 @@ pub(crate) enum PropType {
 }
 
 impl TryFrom<u8> for PropType {
-    type Error = String;
-    fn try_from(v: u8) -> std::result::Result<Self, String> {
+    type Error = Error;
+    fn try_from(v: u8) -> Result<Self> {
         match v {
             0b0000_0000 => Ok(Self::Padding),
             0b0001_0000 => Ok(Self::ContentAddress),
@@ -24,7 +26,7 @@ impl TryFrom<u8> for PropType {
             0b1000_0000 => Ok(Self::VariantId),
             0b1010_0000 => Ok(Self::DeportedUnsignedInt),
             0b1011_0000 => Ok(Self::DeportedSignedInt),
-            _ => Err(format!("Invalid property type ({v})")),
+            _ => Err(format_error!(format!("Invalid property type ({v})"))),
         }
     }
 }

--- a/src/bases/types/byte_size.rs
+++ b/src/bases/types/byte_size.rs
@@ -35,7 +35,9 @@ impl TryFrom<usize> for ByteSize {
 impl Parsable for ByteSize {
     type Output = Self;
     fn parse(parser: &mut impl Parser) -> Result<Self> {
-        Ok((parser.read_u8()? as usize).try_into()?)
+        (parser.read_u8()? as usize)
+            .try_into()
+            .map_err(|_e| format_error!("Invalid ByteSize"))
     }
 }
 impl SizedParsable for ByteSize {

--- a/src/bases/types/error.rs
+++ b/src/bases/types/error.rs
@@ -75,11 +75,7 @@ pub enum ErrorKind {
 
     /// Something in the archive cannot be read because Jubako has not be compile with
     /// the right feature.
-    MissingFeature {
-        feature_name: String,
-        msg: String,
-    },
-    NotFound(String),
+    MissingFeature { feature_name: String, msg: String },
 }
 
 pub struct Error {
@@ -131,10 +127,6 @@ impl Error {
             feature_name: feature_name.into(),
             msg: msg.into(),
         })
-    }
-
-    pub fn notfound(msg: impl Into<String>) -> Self {
-        Error::new(ErrorKind::NotFound(msg.into()))
     }
 
     pub fn corrupted(buf: Vec<u8>, found_crc: [u8; 4]) -> Self {
@@ -202,7 +194,6 @@ impl fmt::Display for Error {
                     "You may want to reinstall you tool with feature {feature_name}"
                 )
             }
-            ErrorKind::NotFound(msg) => writeln!(f, "{msg}"),
         }
     }
 }

--- a/src/bases/types/error.rs
+++ b/src/bases/types/error.rs
@@ -64,12 +64,6 @@ pub enum ErrorKind {
     /// This is not a Jubako file
     NotAJbk,
 
-    /// Type of the given value (at creation) doesn't correspond to the property type.
-    ///
-    /// This almost always because of a bug in the calling code.
-    /// This could, and maybe will, be replaced by assert.
-    WrongType(String),
-
     /// Something in the archive cannot be read because Jubako has not be compile with
     /// the right feature.
     MissingFeature { feature_name: String, msg: String },
@@ -112,9 +106,6 @@ impl Error {
         Error::new(ErrorKind::Version(major, minor))
     }
 
-    pub fn wrong_type(msg: impl Into<String>) -> Self {
-        Error::new(ErrorKind::WrongType(msg.into()))
-    }
     pub fn missfeature(feature_name: impl Into<String>, msg: impl Into<String>) -> Self {
         Error::new(ErrorKind::MissingFeature {
             feature_name: feature_name.into(),
@@ -178,7 +169,6 @@ impl fmt::Display for Error {
                 )
             }
             ErrorKind::NotAJbk => write!(f, "This is not a Jubako archive"),
-            ErrorKind::WrongType(msg) => write!(f, "Wrong type: {msg}"),
             ErrorKind::MissingFeature { feature_name, msg } => {
                 writeln!(f, "{msg}")?;
                 writeln!(

--- a/src/bases/types/error.rs
+++ b/src/bases/types/error.rs
@@ -64,9 +64,6 @@ pub enum ErrorKind {
     /// This is not a Jubako file
     NotAJbk,
 
-    /// Arg given to the function/method is not valid (out of bound, ...)
-    Arg(String),
-
     /// Type of the given value (at creation) doesn't correspond to the property type.
     ///
     /// This almost always because of a bug in the calling code.
@@ -109,10 +106,6 @@ impl Error {
     #[cfg(not(debug_assertions))]
     pub fn new(error: ErrorKind) -> Error {
         Error { error }
-    }
-
-    pub fn arg(msg: impl ToString) -> Error {
-        Error::new(ErrorKind::Arg(msg.to_string()))
     }
 
     pub fn version_error(major: u8, minor: u8) -> Error {
@@ -185,7 +178,6 @@ impl fmt::Display for Error {
                 )
             }
             ErrorKind::NotAJbk => write!(f, "This is not a Jubako archive"),
-            ErrorKind::Arg(msg) => write!(f, "Invalid argument: {msg}"),
             ErrorKind::WrongType(msg) => write!(f, "Wrong type: {msg}"),
             ErrorKind::MissingFeature { feature_name, msg } => {
                 writeln!(f, "{msg}")?;

--- a/src/bases/types/error.rs
+++ b/src/bases/types/error.rs
@@ -27,10 +27,10 @@ impl FormatError {
 //#[macro_export]
 macro_rules! format_error {
     ($what:expr, $stream:ident) => {
-        FormatError::new($what, Some($stream.global_offset())).into()
+        crate::bases::FormatError::new($what, Some($stream.global_offset())).into()
     };
     ($what:expr) => {
-        FormatError::new($what, None).into()
+        crate::bases::FormatError::new($what, None).into()
     };
 }
 

--- a/src/bases/types/mod.rs
+++ b/src/bases/types/mod.rs
@@ -22,7 +22,7 @@ pub(crate) use base_array::BaseArray;
 pub(crate) use byte_size::ByteSize;
 pub(crate) use count::Count;
 pub use delayed::{Bound, Late, SyncType, Vow, Word};
-pub(crate) use error::FormatError;
+pub(crate) use error::{CorruptedFile, FormatError, MissingFeatureError, VersionError};
 pub use error::{Error, ErrorKind, Result};
 pub use free_data::{IndexFreeData, PackFreeData};
 pub(crate) use id::Id;

--- a/src/bin/jbk/locate.rs
+++ b/src/bin/jbk/locate.rs
@@ -41,7 +41,10 @@ pub fn run(options: Options) -> jbk::Result<()> {
         let uuid = uuid.unwrap();
 
         match jbk::tools::set_location(options.infile, uuid, location.as_bytes().to_owned()) {
-            Ok((pack_kind, old_location)) => {
+            Ok(None) => {
+                eprintln!("Pack {uuid} is not in the manifest");
+            }
+            Ok(Some((pack_kind, old_location))) => {
                 let old_location = String::from_utf8_lossy(&old_location);
                 println!(
                     "Change {:?} pack {} location from `{}` to `{}`",

--- a/src/common/check.rs
+++ b/src/common/check.rs
@@ -83,14 +83,14 @@ impl CheckInfo {
         Self { b3hash: None }
     }
 
-    pub(crate) fn new_blake3(source: &mut dyn Read) -> Result<Self> {
+    pub(crate) fn new_blake3(source: &mut dyn Read) -> std::io::Result<Self> {
         let mut hasher = blake3::Hasher::new();
         hasher.update_reader(source)?;
         let hash = hasher.finalize();
         Ok(Self { b3hash: Some(hash) })
     }
 
-    pub(crate) fn check(&self, source: &mut dyn Read) -> Result<bool> {
+    pub(crate) fn check(&self, source: &mut dyn Read) -> std::io::Result<bool> {
         if let Some(b3hash) = self.b3hash {
             let mut hasher = blake3::Hasher::new();
             hasher.update_reader(source)?;

--- a/src/common/headers/pack.rs
+++ b/src/common/headers/pack.rs
@@ -62,7 +62,11 @@ impl Parsable for PackHeader {
         let major_version = parser.read_u8()?;
         let minor_version = parser.read_u8()?;
         if (major_version, minor_version) != (0, 2) {
-            return Err(Error::version_error(major_version, minor_version));
+            return Err(VersionError {
+                major: major_version,
+                minor: minor_version,
+            }
+            .into());
         }
         let uuid = Uuid::parse(parser)?;
         let flags = parser.read_u8()?;

--- a/src/creator/basic_creator.rs
+++ b/src/creator/basic_creator.rs
@@ -213,7 +213,7 @@ impl BasicCreator {
         &mut self,
         content: Box<dyn InputReader>,
         comp_hint: CompHint,
-    ) -> Result<ContentAddress> {
+    ) -> std::io::Result<ContentAddress> {
         self.content_pack.add_content(content, comp_hint)
     }
 }
@@ -223,7 +223,7 @@ impl ContentAdder for BasicCreator {
         &mut self,
         content: Box<dyn InputReader>,
         comp_hint: CompHint,
-    ) -> Result<ContentAddress> {
+    ) -> std::io::Result<ContentAddress> {
         self.add_content(content, comp_hint)
     }
 }

--- a/src/creator/basic_creator.rs
+++ b/src/creator/basic_creator.rs
@@ -9,7 +9,11 @@ use super::{
     AtomicOutFile, Compression, ContainerPackCreator, ContentPackCreator, DirectoryPackCreator,
     InContainerFile, InputReader, ManifestPackCreator, PackRecipient, Progress,
 };
-use crate::{bases::*, ContentAddress};
+use crate::{
+    bases::*,
+    creator::{Error, Result},
+    ContentAddress,
+};
 
 /// How packs will be stored
 #[derive(Clone, Copy)]
@@ -155,7 +159,7 @@ impl BasicCreator {
             .map(|extra_creator| {
                 let (extra_pack_file, extra_pack_info) = extra_creator.finalize()?;
                 let extra_locator = extra_pack_file.close_file()?;
-                Ok::<_, crate::Error>((extra_pack_info, extra_locator))
+                Ok::<_, Error>((extra_pack_info, extra_locator))
             })
             .collect::<Result<Vec<_>>>()?;
 

--- a/src/creator/container_pack.rs
+++ b/src/creator/container_pack.rs
@@ -1,5 +1,6 @@
 use crate::bases::*;
 use crate::common::{CheckInfo, ContainerPackHeader, PackHeader, PackHeaderInfo, PackLocator};
+use crate::creator::Result;
 use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::path::Path;
 

--- a/src/creator/content_pack/cluster.rs
+++ b/src/creator/content_pack/cluster.rs
@@ -37,7 +37,7 @@ impl ClusterCreator {
         self.data.is_empty()
     }
 
-    pub fn add_content(&mut self, content: Box<dyn InputReader>) -> Result<ContentInfo> {
+    pub fn add_content(&mut self, content: Box<dyn InputReader>) -> std::io::Result<ContentInfo> {
         assert!(self.offsets.len() < MAX_BLOBS_PER_CLUSTER);
         let content_size = content.size();
         let idx = self.offsets.len() as u16;

--- a/src/creator/content_pack/clusterwriter.rs
+++ b/src/creator/content_pack/clusterwriter.rs
@@ -28,7 +28,7 @@ fn lz4_compress<'b>(
     data: &mut InputData,
     stream: &'b mut dyn OutStream,
     level: u32,
-) -> Result<&'b mut dyn OutStream> {
+) -> std::io::Result<&'b mut dyn OutStream> {
     let mut encoder = lz4::EncoderBuilder::new()
         .level(level)
         .block_size(lz4::BlockSize::Max4MB)
@@ -48,7 +48,7 @@ fn lzma_compress<'b>(
     data: &mut InputData,
     stream: &'b mut dyn OutStream,
     level: u32,
-) -> Result<&'b mut dyn OutStream> {
+) -> std::io::Result<&'b mut dyn OutStream> {
     let mut encoder = xz2::write::XzEncoder::new_stream(
         stream,
         xz2::stream::Stream::new_lzma_encoder(&xz2::stream::LzmaOptions::new_preset(level)?)?,
@@ -56,7 +56,7 @@ fn lzma_compress<'b>(
     for mut in_reader in data.drain(..) {
         std::io::copy(&mut in_reader, &mut encoder)?;
     }
-    Ok(encoder.finish()?)
+    encoder.finish()
 }
 
 #[cfg(feature = "zstd")]
@@ -64,7 +64,7 @@ fn zstd_compress<'b>(
     data: &mut InputData,
     stream: &'b mut dyn OutStream,
     level: i32,
-) -> Result<&'b mut dyn OutStream> {
+) -> std::io::Result<&'b mut dyn OutStream> {
     let mut encoder = zstd::Encoder::new(stream, level)?;
     encoder.include_contentsize(false)?;
     encoder.include_checksum(false)?;
@@ -72,7 +72,7 @@ fn zstd_compress<'b>(
     for mut in_reader in data.drain(..) {
         std::io::copy(&mut in_reader, &mut encoder)?;
     }
-    Ok(encoder.finish()?)
+    encoder.finish()
 }
 
 struct ClusterCompressor {
@@ -87,7 +87,7 @@ fn serialize_cluster_tail(
     cluster: &ClusterCreator,
     raw_data_size: Size,
     ser: &mut Serializer,
-) -> Result<()> {
+) -> std::io::Result<()> {
     let offset_size = needed_bytes(cluster.data_size().into_u64());
     let cluster_header = ClusterHeader::new(
         compression.into(),
@@ -124,7 +124,7 @@ impl ClusterCompressor {
         &mut self,
         cluster: &mut ClusterCreator,
         outstream: &mut dyn OutStream,
-    ) -> Result<()> {
+    ) -> std::io::Result<()> {
         match &self.compression {
             Compression::None => unreachable!(),
             #[cfg(feature = "lz4")]
@@ -141,7 +141,7 @@ impl ClusterCompressor {
         &mut self,
         mut cluster: ClusterCreator,
         outstream: &mut dyn OutStream,
-    ) -> Result<SizedOffset> {
+    ) -> std::io::Result<SizedOffset> {
         self.progress.handle_cluster(cluster.index.into(), true);
         let data_offset = outstream.tell();
         self.write_cluster_data(&mut cluster, outstream)?;
@@ -160,7 +160,7 @@ impl ClusterCompressor {
         })
     }
 
-    pub fn run(mut self) -> Result<()> {
+    pub fn run(mut self) -> std::io::Result<()> {
         while let Ok(cluster) = self.input.recv() {
             //[TODO] Avoid allocation. Reuse the data once it is written ?
             let mut data = Vec::<u8>::with_capacity(1024 * 1024);
@@ -213,7 +213,7 @@ where
         }
     }
 
-    fn write_cluster_data(&mut self, cluster_data: InputData) -> Result<u64> {
+    fn write_cluster_data(&mut self, cluster_data: InputData) -> std::io::Result<u64> {
         let mut copied = 0;
         for d in cluster_data.into_iter() {
             let (read, to_drop) = self.file.copy(d)?;
@@ -223,7 +223,7 @@ where
         Ok(copied)
     }
 
-    fn write_cluster(&mut self, mut cluster: ClusterCreator) -> Result<SizedOffset> {
+    fn write_cluster(&mut self, mut cluster: ClusterCreator) -> std::io::Result<SizedOffset> {
         self.progress
             .handle_cluster(cluster.index.into_u32(), false);
         let start_offset = self.file.tell();
@@ -244,13 +244,13 @@ where
         })
     }
 
-    fn write_data(&mut self, data: &[u8]) -> Result<Offset> {
+    fn write_data(&mut self, data: &[u8]) -> std::io::Result<Offset> {
         let offset = self.file.tell();
         self.file.write_all(data)?;
         Ok(offset)
     }
 
-    pub fn run(mut self) -> Result<(O, Vec<Late<SizedOffset>>)> {
+    pub fn run(mut self) -> std::io::Result<(O, Vec<Late<SizedOffset>>)> {
         while let Ok(task) = self.input.recv() {
             let (sized_offset, idx) = match task {
                 WriteTask::Cluster(cluster) => {
@@ -279,8 +279,8 @@ where
 }
 
 pub(super) struct ClusterWriterProxy<O: OutStream> {
-    worker_threads: Vec<JoinHandle<Result<()>>>,
-    thread_handle: JoinHandle<Result<(O, Vec<Late<SizedOffset>>)>>,
+    worker_threads: Vec<JoinHandle<std::io::Result<()>>>,
+    thread_handle: JoinHandle<std::io::Result<(O, Vec<Late<SizedOffset>>)>>,
     dispatch_tx: spmc::Sender<ClusterCreator>,
     fusion_tx: mpsc::Sender<WriteTask>, // FIXME: Should we use a `mpsc::SyncSender` instead ?
     nb_cluster_in_queue: Arc<(Mutex<usize>, Condvar)>,
@@ -334,7 +334,11 @@ impl<O: OutStream + 'static> ClusterWriterProxy<O> {
         }
     }
 
-    pub fn write_cluster(&mut self, cluster: ClusterCreator, compressed: bool) -> Result<()> {
+    pub fn write_cluster(
+        &mut self,
+        cluster: ClusterCreator,
+        compressed: bool,
+    ) -> std::io::Result<()> {
         let should_compress = if let Compression::None = self.compression {
             false
         } else {
@@ -357,7 +361,7 @@ impl<O: OutStream + 'static> ClusterWriterProxy<O> {
         Ok(())
     }
 
-    pub fn finalize(self) -> Result<(O, Vec<Late<SizedOffset>>)> {
+    pub fn finalize(self) -> std::io::Result<(O, Vec<Late<SizedOffset>>)> {
         drop(self.dispatch_tx);
         drop(self.fusion_tx);
         for thread in self.worker_threads {

--- a/src/creator/content_pack/creator.rs
+++ b/src/creator/content_pack/creator.rs
@@ -71,7 +71,7 @@ impl ContentPackCreator<NamedFile> {
         app_vendor_id: VendorId,
         free_data: PackFreeData,
         compression: Compression,
-    ) -> Result<Self> {
+    ) -> std::io::Result<Self> {
         Self::new_with_progress(
             path,
             pack_id,
@@ -89,7 +89,7 @@ impl ContentPackCreator<NamedFile> {
         free_data: PackFreeData,
         compression: Compression,
         progress: Arc<dyn Progress>,
-    ) -> Result<Self> {
+    ) -> std::io::Result<Self> {
         let file = NamedFile::new(path)?;
         Self::new_from_output_with_progress(
             file,
@@ -109,7 +109,7 @@ impl<O: PackRecipient + 'static + ?Sized> ContentPackCreator<O> {
         app_vendor_id: VendorId,
         free_data: PackFreeData,
         compression: Compression,
-    ) -> Result<Self> {
+    ) -> std::io::Result<Self> {
         Self::new_from_output_with_progress(
             file,
             pack_id,
@@ -127,7 +127,7 @@ impl<O: PackRecipient + 'static + ?Sized> ContentPackCreator<O> {
         free_data: PackFreeData,
         compression: Compression,
         progress: Arc<dyn Progress>,
-    ) -> Result<Self> {
+    ) -> std::io::Result<Self> {
         file.seek(SeekFrom::Start(
             (PackHeader::BLOCK_SIZE + ContentPackHeader::BLOCK_SIZE) as u64,
         ))?;
@@ -163,7 +163,7 @@ impl<O: PackRecipient + 'static + ?Sized> ContentPackCreator<O> {
         &mut self,
         compressed: bool,
         content_size: Size,
-    ) -> Result<&mut ClusterCreator> {
+    ) -> std::io::Result<&mut ClusterCreator> {
         // Let's get raw cluster
         if let Some(cluster) = self.setup_slot_and_get_to_close(content_size, compressed) {
             self.cluster_writer.write_cluster(cluster, compressed)?;
@@ -195,7 +195,7 @@ impl<O: PackRecipient + 'static + ?Sized> ContentPackCreator<O> {
         &self,
         content: &mut dyn InputReader,
         comp_hint: CompHint,
-    ) -> Result<bool> {
+    ) -> std::io::Result<bool> {
         if let Compression::None = self.compression {
             return Ok(false);
         }
@@ -218,7 +218,7 @@ impl<O: PackRecipient + 'static + ?Sized> ContentPackCreator<O> {
         &mut self,
         mut content: Box<dyn InputReader>,
         comp_hint: CompHint,
-    ) -> Result<ContentAddress> {
+    ) -> std::io::Result<ContentAddress> {
         let content_size = content.size();
         self.progress.content_added(content_size);
         let should_compress = self.detect_compression(content.as_mut(), comp_hint)?;
@@ -235,13 +235,13 @@ impl<O: PackRecipient + 'static + ?Sized> ContentAdder for ContentPackCreator<O>
         &mut self,
         content: Box<dyn InputReader>,
         comp_hint: CompHint,
-    ) -> Result<ContentAddress> {
+    ) -> std::io::Result<ContentAddress> {
         self.add_content(content, comp_hint)
     }
 }
 
 impl<O: PackRecipient + 'static + ?Sized> ContentPackCreator<O> {
-    pub fn finalize(mut self) -> Result<(Box<O>, PackData)> {
+    pub fn finalize(mut self) -> std::io::Result<(Box<O>, PackData)> {
         info!("======= Finalize creation =======");
 
         if let Some(cluster) = self.raw_open_cluster.take() {

--- a/src/creator/content_pack/creator.rs
+++ b/src/creator/content_pack/creator.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 
 use log::info;
 
-fn shannon_entropy(data: &[u8]) -> Result<f32> {
+fn shannon_entropy(data: &[u8]) -> f32 {
     let mut entropy = 0.0;
     let mut counts = [0; 256];
 
@@ -31,7 +31,7 @@ fn shannon_entropy(data: &[u8]) -> Result<f32> {
         entropy -= p * p.log(2.0);
     }
 
-    Ok(entropy)
+    entropy
 }
 
 pub struct ContentPackCreator<O: PackRecipient + ?Sized> {
@@ -207,7 +207,7 @@ impl<O: PackRecipient + 'static + ?Sized> ContentPackCreator<O> {
                 {
                     content.take(4 * 1024).read_to_end(&mut head)?;
                 }
-                let entropy = shannon_entropy(&head)?;
+                let entropy = shannon_entropy(&head);
                 content.seek(SeekFrom::Start(0))?;
                 Ok(entropy <= 6.0)
             }

--- a/src/creator/content_pack/mod.rs
+++ b/src/creator/content_pack/mod.rs
@@ -46,7 +46,7 @@ pub trait ContentAdder {
         &mut self,
         reader: Box<dyn InputReader>,
         comp_hint: CompHint,
-    ) -> Result<ContentAddress>;
+    ) -> std::io::Result<ContentAddress>;
 }
 
 pub struct CachedContentAdder<Wrapped: ContentAdder + 'static> {
@@ -74,7 +74,7 @@ impl<Wrapped: ContentAdder> CachedContentAdder<Wrapped> {
         hash: Hash,
         reader: Box<dyn InputReader>,
         comp_hint: CompHint,
-    ) -> Result<crate::ContentAddress> {
+    ) -> std::io::Result<crate::ContentAddress> {
         match self.cache.entry(hash) {
             Entry::Vacant(e) => {
                 let content_address = self.content_pack.add_content(reader, comp_hint)?;
@@ -92,7 +92,7 @@ impl<Wrapped: ContentAdder> CachedContentAdder<Wrapped> {
         &mut self,
         mut reader: Box<dyn InputReader>,
         comp_hint: CompHint,
-    ) -> Result<crate::ContentAddress> {
+    ) -> std::io::Result<crate::ContentAddress> {
         let mut hasher = blake3::Hasher::new();
         if reader.size() < cluster::CLUSTER_SIZE {
             let mut buf = Vec::with_capacity(reader.size().into_u64() as usize);
@@ -114,7 +114,7 @@ impl<Wrapper: ContentAdder> ContentAdder for CachedContentAdder<Wrapper> {
         &mut self,
         reader: Box<dyn InputReader>,
         comp_hint: CompHint,
-    ) -> Result<crate::ContentAddress> {
+    ) -> std::io::Result<crate::ContentAddress> {
         self.add_content(reader, comp_hint)
     }
 }

--- a/src/creator/directory_pack/directory_pack.rs
+++ b/src/creator/directory_pack/directory_pack.rs
@@ -4,7 +4,7 @@ use crate::common::{
     CheckInfo, CheckKind, DirectoryPackHeader, PackHeader, PackHeaderInfo, PackKind,
 };
 use crate::creator::private::WritableTell;
-use crate::creator::PackData;
+use crate::creator::{PackData, Result};
 use entry_store::EntryStoreTrait;
 use std::io::{BufWriter, Seek, SeekFrom, Write};
 use value_store::StoreHandle;

--- a/src/creator/directory_pack/directory_pack.rs
+++ b/src/creator/directory_pack/directory_pack.rs
@@ -55,7 +55,7 @@ impl DirectoryPackCreator {
         self.indexes.push(index);
     }
 
-    pub fn finalize(self) -> Result<FinalizedDirectoryPackCreator> {
+    pub fn finalize(self) -> std::io::Result<FinalizedDirectoryPackCreator> {
         info!("======= Finalize creation =======");
 
         info!("----- Finalize value_stores -----");

--- a/src/creator/directory_pack/entry_store.rs
+++ b/src/creator/directory_pack/entry_store.rs
@@ -2,6 +2,7 @@ use super::schema;
 use super::{FullEntryTrait, PropertyName, VariantName};
 use crate::bases::*;
 use crate::creator::private::WritableTell;
+use crate::creator::Result;
 use rayon::prelude::*;
 
 use log::debug;

--- a/src/creator/directory_pack/entry_store.rs
+++ b/src/creator/directory_pack/entry_store.rs
@@ -132,7 +132,7 @@ where
         Ok(())
     }
 
-    fn serialize_tail(&mut self, ser: &mut Serializer) -> Result<()> {
+    fn serialize_tail(&mut self, ser: &mut Serializer) -> std::io::Result<()> {
         ser.write_u8(0x00)?; // kind
         let entry_count = EntryCount::from(self.entries.len() as u32);
         entry_count.serialize(ser)?;

--- a/src/creator/directory_pack/layout/entry.rs
+++ b/src/creator/directory_pack/layout/entry.rs
@@ -3,6 +3,7 @@ use super::properties::Properties;
 use crate::bases::Serializable;
 use crate::bases::*;
 use crate::creator::directory_pack::EntryTrait;
+use crate::creator::Result;
 use std::collections::HashMap;
 
 #[derive(Debug)]

--- a/src/creator/directory_pack/layout/properties.rs
+++ b/src/creator/directory_pack/layout/properties.rs
@@ -4,6 +4,7 @@ use super::Value;
 use crate::bases::Serializable;
 use crate::bases::*;
 use crate::creator::directory_pack::EntryTrait;
+use crate::creator::{Error, Result};
 
 #[derive(Debug)]
 #[repr(transparent)]

--- a/src/creator/directory_pack/layout/properties.rs
+++ b/src/creator/directory_pack/layout/properties.rs
@@ -122,19 +122,15 @@ impl<PN: PropertyName + 'static> Properties<PN> {
                         Value::IndirectArray(value_id) => {
                             assert_eq!(*array_len_size, None); // We don't store the size of the array
                             assert_eq!(*fixed_array_len, 0); // No fixed array
-                            if let Some((key_size, _)) = deported_info {
-                                written +=
-                                    ser.write_usized(value_id.get().into_u64(), *key_size)?;
-                            } else {
-                                return Err(
-                                    "A indirect array need a array property with a deported info"
-                                        .to_string()
-                                        .into(),
-                                );
-                            }
+                            assert!(deported_info.is_some()); // We must have a deported_info
+                            let (key_size, _) = deported_info.as_ref().unwrap();
+                            written += ser.write_usized(value_id.get().into_u64(), *key_size)?;
                         }
                         _ => {
-                            return Err("Not a Array".to_string().into());
+                            return Err(Error::wrong_type(format!(
+                                "Value type for {} is not compatible with Array",
+                                name.to_string()
+                            )));
                         }
                     }
                 }
@@ -147,7 +143,10 @@ impl<PN: PropertyName + 'static> Properties<PN> {
                         written += ser.write_usized(value_id.get().into_u64(), *value_id_size)?;
                     }
                     _ => {
-                        return Err("Not a indirect Array".to_string().into());
+                        return Err(Error::wrong_type(format!(
+                            "Value type for {} is not compatible with indirect array",
+                            name.to_string()
+                        )));
                     }
                 },
                 Property::ContentAddress {
@@ -166,7 +165,10 @@ impl<PN: PropertyName + 'static> Properties<PN> {
                             ser.write_usized(value.content_id.into_u64(), *content_id_size)?;
                     }
                     _ => {
-                        return Err("Not a Content".to_string().into());
+                        return Err(Error::wrong_type(format!(
+                            "Value type for {} is not compatible with content",
+                            name.to_string()
+                        )));
                     }
                 },
                 Property::UnsignedInt {
@@ -189,7 +191,10 @@ impl<PN: PropertyName + 'static> Properties<PN> {
                         }
                     }
                     _ => {
-                        return Err("Not a unsigned".to_string().into());
+                        return Err(Error::wrong_type(format!(
+                            "Value type for {} is not compatible with unsigned integer",
+                            name.to_string()
+                        )));
                     }
                 },
                 Property::SignedInt {
@@ -212,7 +217,10 @@ impl<PN: PropertyName + 'static> Properties<PN> {
                         }
                     }
                     _ => {
-                        return Err("Not a unsigned".to_string().into());
+                        return Err(Error::wrong_type(format!(
+                            "Value type for {} is not compatible with signed integer",
+                            name.to_string()
+                        )));
                     }
                 },
                 Property::Padding(size) => {

--- a/src/creator/directory_pack/mod.rs
+++ b/src/creator/directory_pack/mod.rs
@@ -332,7 +332,7 @@ impl super::private::WritableTell for Index {
         // No data to write
         Ok(())
     }
-    fn serialize_tail(&mut self, ser: &mut Serializer) -> Result<()> {
+    fn serialize_tail(&mut self, ser: &mut Serializer) -> IoResult<()> {
         self.store_id.serialize(ser)?;
         self.count.serialize(ser)?;
         self.offset.get().serialize(ser)?;

--- a/src/creator/directory_pack/mod.rs
+++ b/src/creator/directory_pack/mod.rs
@@ -8,6 +8,7 @@ mod value_store;
 
 use crate::bases::*;
 use crate::common;
+use crate::creator::Result;
 pub use directory_pack::DirectoryPackCreator;
 pub use entry_store::EntryStore;
 use std::cmp;

--- a/src/creator/directory_pack/schema/entry.rs
+++ b/src/creator/directory_pack/schema/entry.rs
@@ -1,7 +1,7 @@
 use super::properties::{CommonProperties, Properties, VariantProperties};
 use crate::bases::Writable;
 use crate::bases::*;
-use crate::creator::directory_pack::EntryTrait;
+use crate::creator::{directory_pack::EntryTrait, Result};
 
 #[derive(Debug)]
 struct Entry {

--- a/src/creator/directory_pack/value_store.rs
+++ b/src/creator/directory_pack/value_store.rs
@@ -17,7 +17,7 @@ pub struct ValueHandle {
 }
 
 impl std::fmt::Debug for ValueHandle {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ValueHandle")
             .field("store", &"Unknown")
             .field("idx", &self.idx.get())

--- a/src/creator/directory_pack/value_store.rs
+++ b/src/creator/directory_pack/value_store.rs
@@ -185,7 +185,7 @@ impl WritableTell for ValueStore {
         }
     }
 
-    fn serialize_tail(&mut self, ser: &mut Serializer) -> Result<()> {
+    fn serialize_tail(&mut self, ser: &mut Serializer) -> IoResult<()> {
         match self {
             Self::Plain(s) => s.serialize_tail(ser),
             Self::Indexed(s) => s.serialize_tail(ser),
@@ -305,7 +305,7 @@ impl WritableTell for PlainValueStore {
         Ok(())
     }
 
-    fn serialize_tail(&mut self, ser: &mut Serializer) -> Result<()> {
+    fn serialize_tail(&mut self, ser: &mut Serializer) -> IoResult<()> {
         ser.write_u8(0x00)?;
         self.size().serialize(ser)?;
         Ok(())
@@ -385,7 +385,7 @@ impl WritableTell for IndexedValueStore {
         Ok(())
     }
 
-    fn serialize_tail(&mut self, ser: &mut Serializer) -> Result<()> {
+    fn serialize_tail(&mut self, ser: &mut Serializer) -> IoResult<()> {
         ser.write_u8(0x01)?;
         ser.write_u64(self.0.sorted_indirect.len() as u64)?; // key count
         let data_size = self.0.size.into_u64();

--- a/src/creator/directory_pack/value_store.rs
+++ b/src/creator/directory_pack/value_store.rs
@@ -1,5 +1,5 @@
 use crate::bases::*;
-use crate::creator::private::WritableTell;
+use crate::creator::{private::WritableTell, Result};
 use rayon::prelude::*;
 use std::cell::Cell;
 

--- a/src/creator/errors.rs
+++ b/src/creator/errors.rs
@@ -1,0 +1,61 @@
+use std::fmt;
+use std::string::FromUtf16Error;
+
+#[derive(Debug)]
+/// Error type used on creation side.
+pub enum Error {
+    /// Io error. Can be raised by any error on the underlying system.
+    Io(std::io::Error),
+
+    UTF16(FromUtf16Error),
+
+    /// Type of the given value (at creation) doesn't correspond to the property type.
+    ///
+    /// This almost always because of a bug in the calling code.
+    /// This could, and maybe will, be replaced by assert.
+    WrongType(String),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+impl From<std::io::Error> for Error {
+    fn from(value: std::io::Error) -> Self {
+        Error::Io(value)
+    }
+}
+
+impl From<FromUtf16Error> for Error {
+    fn from(value: FromUtf16Error) -> Self {
+        Error::UTF16(value)
+    }
+}
+
+impl Error {
+    pub fn wrong_type(msg: impl Into<String>) -> Self {
+        Error::WrongType(msg.into())
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Io(e) => writeln!(f, "IO error {e}"),
+            Error::UTF16(e) => writeln!(f, "{e}"),
+            Error::WrongType(e) => writeln!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    #[cfg(feature = "nightly")]
+    fn provide<'a>(&'a self, request: &mut std::error::Request<'a>) {
+        #[cfg(debug_assertions)]
+        request.provide_ref::<Backtrace>(&self.bt);
+        match &self.error {
+            Error::Io(e) => request.provide_ref::<std::io::Error>(e),
+            Error::UTF16(e) => request.provide_ref::<std::io::Error>(e),
+            Error::WrongType(e) => request.provide_ref::<std::io::Error>(e),
+            _ => request, /* Nothing*/
+        };
+    }
+}

--- a/src/creator/manifest_pack.rs
+++ b/src/creator/manifest_pack.rs
@@ -4,6 +4,7 @@ use crate::common::{
     CheckInfo, CheckKind, ManifestCheckStream, ManifestPackHeader, PackHeader, PackHeaderInfo,
     PackInfo, PackKind,
 };
+use crate::creator::Result;
 use std::io::SeekFrom;
 
 pub struct ManifestPackCreator {

--- a/src/reader/byte_region.rs
+++ b/src/reader/byte_region.rs
@@ -87,7 +87,7 @@ impl RandomParser for ByteRegion {
         self.source.get_slice(region, BlockCheck::None)
     }
 
-    fn read_data(&self, offset: Offset, buf: &mut [u8]) -> Result<()> {
+    fn read_data(&self, offset: Offset, buf: &mut [u8]) -> IoResult<()> {
         self.source.read_exact(self.region.begin() + offset, buf)
     }
 }

--- a/src/reader/byte_slice.rs
+++ b/src/reader/byte_slice.rs
@@ -76,7 +76,7 @@ impl<'s> RandomParser for ByteSlice<'s> {
         self.source.get_slice(region, BlockCheck::None)
     }
 
-    fn read_data(&self, offset: Offset, buf: &mut [u8]) -> Result<()> {
+    fn read_data(&self, offset: Offset, buf: &mut [u8]) -> IoResult<()> {
         self.source.read_exact(self.region.begin() + offset, buf)
     }
 }

--- a/src/reader/container_pack.rs
+++ b/src/reader/container_pack.rs
@@ -130,12 +130,12 @@ impl graphex::Node for ContainerPack {
             let uuid = self
                 .packs_uuid
                 .get(index)
-                .ok_or_else(|| Error::from(format!("{item} is not a valid key.")))?;
+                .ok_or_else(|| graphex::Error::key(&format!("{item} is not a valid key.")))?;
             &self.packs[uuid]
         } else if let Ok(uuid) = item.parse::<Uuid>() {
             self.packs
                 .get(&uuid)
-                .ok_or_else(|| Error::from(format!("{item} is not a valid key.")))?
+                .ok_or_else(|| graphex::Error::key(&format!("{item} is not a valid key.")))?
         } else {
             return Err(graphex::Error::key("Invalid key"));
         };

--- a/src/reader/content_pack/cluster.rs
+++ b/src/reader/content_pack/cluster.rs
@@ -28,9 +28,10 @@ fn lz4_source(raw_stream: ByteStream, data_size: ASize) -> Result<Arc<dyn Source
 
 #[cfg(not(feature = "lz4"))]
 fn lz4_source(_raw_stream: ByteStream, _data_size: ASize) -> Result<Arc<dyn Source>> {
-    Err("Lz4 compression is not supported in this configuration."
-        .to_string()
-        .into())
+    Err(Error::missfeature(
+        "lz4",
+        "Lz4 compression is not supported in this configuration.",
+    ))
 }
 
 #[cfg(feature = "lzma")]
@@ -46,9 +47,10 @@ fn lzma_source(raw_stream: ByteStream, data_size: ASize) -> Result<Arc<dyn Sourc
 
 #[cfg(not(feature = "lzma"))]
 fn lzma_source(_raw_stream: ByteStream, _data_size: ASize) -> Result<Arc<dyn Source>> {
-    Err("Lzma compression is not supported in this configuration."
-        .to_string()
-        .into())
+    Err(Error::missfeature(
+        "lzma",
+        "Lzma compression is not supported in this configuration.",
+    ))
 }
 
 #[cfg(feature = "zstd")]
@@ -61,9 +63,10 @@ fn zstd_source(raw_stream: ByteStream, data_size: ASize) -> Result<Arc<dyn Sourc
 
 #[cfg(not(feature = "zstd"))]
 fn zstd_source(_raw_stream: ByteStream, _data_size: ASize) -> Result<Arc<dyn Source>> {
-    Err("zstd compression is not supported in this configuration."
-        .to_string()
-        .into())
+    Err(Error::missfeature(
+        "zstd",
+        "zstd compression is not supported in this configuration.",
+    ))
 }
 
 impl Cluster {

--- a/src/reader/content_pack/cluster.rs
+++ b/src/reader/content_pack/cluster.rs
@@ -28,10 +28,11 @@ fn lz4_source(raw_stream: ByteStream, data_size: ASize) -> Result<Arc<dyn Source
 
 #[cfg(not(feature = "lz4"))]
 fn lz4_source(_raw_stream: ByteStream, _data_size: ASize) -> Result<Arc<dyn Source>> {
-    Err(Error::missfeature(
-        "lz4",
-        "Lz4 compression is not supported in this configuration.",
-    ))
+    Err(MissingFeatureError {
+        name: "lz4",
+        msg: "Lz4 compression is not supported in this configuration.",
+    }
+    .into())
 }
 
 #[cfg(feature = "lzma")]
@@ -47,10 +48,11 @@ fn lzma_source(raw_stream: ByteStream, data_size: ASize) -> Result<Arc<dyn Sourc
 
 #[cfg(not(feature = "lzma"))]
 fn lzma_source(_raw_stream: ByteStream, _data_size: ASize) -> Result<Arc<dyn Source>> {
-    Err(Error::missfeature(
-        "lzma",
-        "Lzma compression is not supported in this configuration.",
-    ))
+    Err(MissingFeatureError {
+        name: "lzma",
+        msg: "Lzma compression is not supported in this configuration.",
+    }
+    .into())
 }
 
 #[cfg(feature = "zstd")]
@@ -63,10 +65,11 @@ fn zstd_source(raw_stream: ByteStream, data_size: ASize) -> Result<Arc<dyn Sourc
 
 #[cfg(not(feature = "zstd"))]
 fn zstd_source(_raw_stream: ByteStream, _data_size: ASize) -> Result<Arc<dyn Source>> {
-    Err(Error::missfeature(
-        "zstd",
-        "zstd compression is not supported in this configuration.",
-    ))
+    Err(MissingFeatureError {
+        name: "zstd",
+        msg: "zstd compression is not supported in this configuration.",
+    }
+    .into())
 }
 
 impl Cluster {

--- a/src/reader/content_pack/mod.rs
+++ b/src/reader/content_pack/mod.rs
@@ -72,7 +72,7 @@ impl ContentPack {
 
     pub fn get_content(&self, index: ContentIdx) -> Result<ByteRegion> {
         if !index.is_valid(*self.header.content_count) {
-            return Err(Error::new_arg());
+            return Err(Error::arg(format!("Invalid index {index}")));
         }
         let content_info = self.content_infos.index(*index)?;
         if !content_info

--- a/src/reader/content_pack/mod.rs
+++ b/src/reader/content_pack/mod.rs
@@ -193,7 +193,7 @@ impl Pack for ContentPack {
             Size::from(self.pack_header.check_info_pos),
             false,
         )?;
-        check_info.check(&mut check_stream)
+        Ok(check_info.check(&mut check_stream)?)
     }
 }
 

--- a/src/reader/content_pack/mod.rs
+++ b/src/reader/content_pack/mod.rs
@@ -70,9 +70,9 @@ impl ContentPack {
         Ok(cached.clone())
     }
 
-    pub fn get_content(&self, index: ContentIdx) -> Result<ByteRegion> {
+    pub fn get_content(&self, index: ContentIdx) -> Result<Option<ByteRegion>> {
         if !index.is_valid(*self.header.content_count) {
-            return Err(Error::arg(format!("Invalid index {index}")));
+            return Ok(None);
         }
         let content_info = self.content_infos.index(*index)?;
         if !content_info
@@ -85,7 +85,7 @@ impl ContentPack {
             )));
         }
         let cluster = self.get_cluster(content_info.cluster_index)?;
-        cluster.get_bytes(content_info.blob_index)
+        Ok(Some(cluster.get_bytes(content_info.blob_index)?))
     }
 
     pub fn get_free_data(&self) -> &[u8] {
@@ -203,7 +203,7 @@ mod tests {
     use std::io::Read;
 
     #[test]
-    fn test_contentpack() {
+    fn test_contentpack() -> Result<()> {
         let mut content = vec![];
 
         // Pack header offset 0/0x00
@@ -280,7 +280,7 @@ mod tests {
 
         // FileSize 220 + 64 = 284/0x011C (file_size)
 
-        let content_pack = ContentPack::new(content.into()).unwrap();
+        let content_pack = ContentPack::new(content.into())?;
         assert_eq!(content_pack.get_content_count(), ContentCount::from(3));
         assert_eq!(content_pack.app_vendor_id(), VendorId::from([0, 0, 0, 1]));
         assert_eq!(content_pack.version(), (0, 2));
@@ -292,31 +292,38 @@ mod tests {
             ])
         );
         assert_eq!(content_pack.get_free_data(), [0xff; 24]);
-        assert!(&content_pack.check().unwrap());
+        assert!(&content_pack.check()?);
 
         {
-            let bytes = content_pack.get_content(ContentIdx::from(0)).unwrap();
+            let bytes = content_pack
+                .get_content(ContentIdx::from(0))?
+                .expect("0 is a valid content idx");
             assert_eq!(bytes.size(), Size::from(5_u64));
             let mut v = Vec::<u8>::new();
             let mut stream = bytes.stream();
-            stream.read_to_end(&mut v).unwrap();
+            stream.read_to_end(&mut v)?;
             assert_eq!(v, [0x11, 0x12, 0x13, 0x14, 0x15]);
         }
         {
-            let bytes = content_pack.get_content(ContentIdx::from(1)).unwrap();
+            let bytes = content_pack
+                .get_content(ContentIdx::from(1))?
+                .expect("1 is a valid content idx");
             assert_eq!(bytes.size(), Size::from(3_u64));
             let mut v = Vec::<u8>::new();
             let mut stream = bytes.stream();
-            stream.read_to_end(&mut v).unwrap();
+            stream.read_to_end(&mut v)?;
             assert_eq!(v, [0x21, 0x22, 0x23]);
         }
         {
-            let bytes = content_pack.get_content(ContentIdx::from(2)).unwrap();
+            let bytes = content_pack
+                .get_content(ContentIdx::from(2))?
+                .expect("2 is a valid content idx");
             assert_eq!(bytes.size(), Size::from(7_u64));
             let mut v = Vec::<u8>::new();
             let mut stream = bytes.stream();
-            stream.read_to_end(&mut v).unwrap();
+            stream.read_to_end(&mut v)?;
             assert_eq!(v, [0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37]);
         }
+        Ok(())
     }
 }

--- a/src/reader/content_pack/mod.rs
+++ b/src/reader/content_pack/mod.rs
@@ -115,14 +115,14 @@ impl graphex::Node for ContentPack {
         if let Some(item) = key.strip_prefix("e.") {
             let index = item
                 .parse::<u32>()
-                .map_err(|e| Error::from(format!("{e}")))?;
+                .map_err(|e| graphex::Error::key(&format!("{e}")))?;
             let index = ContentIdx::from(index);
             let content_info = self.content_infos.index(*index)?;
             Ok(Box::new(content_info).into())
         } else if let Some(item) = key.strip_prefix("c.") {
             let index = item
                 .parse::<u32>()
-                .map_err(|e| Error::from(format!("{e}")))?;
+                .map_err(|e| graphex::Error::key(&format!("{e}")))?;
             let cluster_info = self.cluster_ptrs.index(index.into())?;
             Ok(Box::new(self.reader.parse_data_block::<Cluster>(cluster_info)?).into())
         } else {

--- a/src/reader/directory_pack/builder/mod.rs
+++ b/src/reader/directory_pack/builder/mod.rs
@@ -102,10 +102,16 @@ impl AnyBuilder {
         Ok(Self { properties, store })
     }
 
+    /// Build a new PropertyCompare to search in a Range.
+    ///
+    /// Search will panic if property_name is not in the entry or if value is not of the right type.
     pub fn new_property_compare(&self, property_name: String, value: Value) -> PropertyCompare {
         PropertyCompare::new(self, vec![property_name], vec![value])
     }
 
+    /// Build a new PropertyCompare from a set of propertie to search in a Range.
+    ///
+    /// Search will panic if property_names are not in the entry or if values are not of the right type.
     pub fn new_multiple_property_compare(
         &self,
         property_names: Vec<String>,

--- a/src/reader/directory_pack/builder/mod.rs
+++ b/src/reader/directory_pack/builder/mod.rs
@@ -28,8 +28,15 @@ impl AnyVariantBuilder {
     pub(super) fn contains(&self, name: &str) -> bool {
         self.properties.contains_key(name)
     }
-    pub(super) fn create_value(&self, name: &str, parser: &impl RandomParser) -> Result<RawValue> {
-        self.properties[name].create(parser)
+    pub(super) fn create_value(
+        &self,
+        name: &str,
+        parser: &impl RandomParser,
+    ) -> Result<Option<RawValue>> {
+        self.properties
+            .get(name)
+            .map(|p| p.create(parser))
+            .transpose()
     }
 
     pub(super) fn new<ValueStorage>(
@@ -198,9 +205,12 @@ mod tests {
             assert!(entry.get_variant_id().unwrap().is_none());
             assert_eq!(
                 entry.get_value("V0").unwrap(),
-                RawValue::Content(ContentAddress::new(0.into(), 0x010000.into()))
+                Some(RawValue::Content(ContentAddress::new(
+                    0.into(),
+                    0x010000.into()
+                )))
             );
-            assert!(entry.get_value("V11").unwrap() == RawValue::U16(0x9988));
+            assert!(entry.get_value("V11").unwrap() == Some(RawValue::U16(0x9988)));
         }
 
         {
@@ -209,9 +219,12 @@ mod tests {
             assert!(entry.get_variant_id().unwrap().is_none());
             assert_eq!(
                 entry.get_value("V0").unwrap(),
-                RawValue::Content(ContentAddress::new(1.into(), 0x020000.into()))
+                Some(RawValue::Content(ContentAddress::new(
+                    1.into(),
+                    0x020000.into()
+                )))
             );
-            assert!(entry.get_value("V11").unwrap() == RawValue::U16(0x7766));
+            assert!(entry.get_value("V11").unwrap() == Some(RawValue::U16(0x7766)));
         }
     }
 
@@ -315,14 +328,14 @@ mod tests {
             assert_eq!(entry.get_variant_id().unwrap(), Some(0.into()));
             assert_eq!(
                 entry.get_value("V0").unwrap(),
-                RawValue::Array(Array::new(
+                Some(RawValue::Array(Array::new(
                     Some(ASize::new(4)),
                     BaseArray::new(&[0xFF, 0xEE, 0xDD, 0xCC]),
                     4,
                     None
-                ))
+                )))
             );
-            assert_eq!(entry.get_value("V1").unwrap(), RawValue::U16(0x8899));
+            assert_eq!(entry.get_value("V1").unwrap(), Some(RawValue::U16(0x8899)));
         }
 
         {
@@ -331,10 +344,15 @@ mod tests {
             assert_eq!(entry.get_variant_id().unwrap(), Some(1.into()));
             assert_eq!(
                 entry.get_value("V0").unwrap(),
-                RawValue::Array(Array::new(None, BaseArray::new(&[0xFF, 0xEE]), 2, None))
+                Some(RawValue::Array(Array::new(
+                    None,
+                    BaseArray::new(&[0xFF, 0xEE]),
+                    2,
+                    None
+                )))
             );
-            assert_eq!(entry.get_value("V2").unwrap(), RawValue::I8(-52));
-            assert_eq!(entry.get_value("V3").unwrap(), RawValue::U16(0x8899));
+            assert_eq!(entry.get_value("V2").unwrap(), Some(RawValue::I8(-52)));
+            assert_eq!(entry.get_value("V3").unwrap(), Some(RawValue::U16(0x8899)));
         }
     }
 }

--- a/src/reader/directory_pack/builder/mod.rs
+++ b/src/reader/directory_pack/builder/mod.rs
@@ -19,7 +19,8 @@ pub use self::property::*;
 
 pub trait BuilderTrait {
     type Entry;
-    fn create_entry(&self, idx: EntryIdx) -> Result<Option<Self::Entry>>;
+    type Error;
+    fn create_entry(&self, idx: EntryIdx) -> std::result::Result<Option<Self::Entry>, Self::Error>;
 }
 
 pub struct AnyVariantBuilder {
@@ -129,6 +130,7 @@ impl AnyBuilder {
 
 impl BuilderTrait for AnyBuilder {
     type Entry = LazyEntry;
+    type Error = Error;
     fn create_entry(&self, idx: EntryIdx) -> Result<Option<LazyEntry>> {
         Ok(self
             .store

--- a/src/reader/directory_pack/builder/mod.rs
+++ b/src/reader/directory_pack/builder/mod.rs
@@ -182,8 +182,7 @@ mod tests {
                         Some("V11".to_string()),
                     ),
                 ],
-            )
-            .unwrap(),
+            ),
             variant_part: None,
             entry_count: EntryCount::from(2),
             is_entry_checked: false,
@@ -231,7 +230,7 @@ mod tests {
     #[test]
     fn create_entry_with_variant() {
         let layout = Layout {
-            common: Properties::new(0, vec![]).unwrap(),
+            common: Properties::new(0, vec![]),
             variant_part: Some(VariantPart {
                 variant_id_offset: Offset::new(0),
                 variants: Box::new([
@@ -258,7 +257,6 @@ mod tests {
                             ),
                         ],
                     )
-                    .unwrap()
                     .into(),
                     Properties::new(
                         1,
@@ -292,7 +290,6 @@ mod tests {
                             ),
                         ],
                     )
-                    .unwrap()
                     .into(),
                 ]),
                 names: HashMap::from([

--- a/src/reader/directory_pack/builder/property.rs
+++ b/src/reader/directory_pack/builder/property.rs
@@ -105,7 +105,9 @@ impl<ValueStorage: ValueStorageTrait> TryFrom<(&layout::Property, &ValueStorage)
                 let store = value_storage.get_value_store(value_store_idx)?;
                 IntProperty::new_from_deported(p.offset, int_size, store, id)
             }
-            _ => Err("Invalid key".to_string().into()),
+            ref other => Err(Error::wrong_type(format!(
+                "Layout property {other:?} is not compatible with integer"
+            ))),
         }
     }
 }
@@ -213,7 +215,9 @@ impl<ValueStorage: ValueStorageTrait> TryFrom<(&layout::Property, &ValueStorage)
                 let store = value_storage.get_value_store(value_store_idx)?;
                 SignedProperty::new_from_deported(p.offset, int_size, store, id)
             }
-            _ => Err("Invalid key".to_string().into()),
+            ref other => Err(Error::wrong_type(format!(
+                "Layout property {other:?} is not compatible with signed integer"
+            ))),
         }
     }
 }
@@ -312,7 +316,9 @@ impl<ValueStorage: ValueStorageTrait> TryFrom<(&layout::Property, &ValueStorage)
                     default,
                 ))
             }
-            _ => Err("Invalid key".to_string().into()),
+            ref other => Err(Error::wrong_type(format!(
+                "Layout property {other:?} is not compatible with array"
+            ))),
         }
     }
 }
@@ -383,7 +389,7 @@ impl ContentProperty {
 }
 
 impl TryFrom<&layout::Property> for ContentProperty {
-    type Error = String;
+    type Error = Error;
     fn try_from(p: &layout::Property) -> std::result::Result<Self, Self::Error> {
         match p.kind {
             layout::PropertyKind::ContentAddress {
@@ -396,7 +402,9 @@ impl TryFrom<&layout::Property> for ContentProperty {
                 pack_id_size,
                 content_id_size,
             )),
-            _ => Err("Invalid key".to_string()),
+            ref other => Err(Error::wrong_type(format!(
+                "Layout property {other:?} is not compatible with content"
+            ))),
         }
     }
 }

--- a/src/reader/directory_pack/builder/property.rs
+++ b/src/reader/directory_pack/builder/property.rs
@@ -1,3 +1,5 @@
+use inner::FromLayoutProperty;
+
 use crate::bases::*;
 use crate::common::ContentAddress;
 use crate::reader::directory_pack::layout;
@@ -18,6 +20,32 @@ use std::sync::Arc;
 pub trait PropertyBuilderTrait {
     type Output;
     fn create(&self, parser: &impl RandomParser) -> Result<Self::Output>;
+}
+
+/// As we want to create a specific property builder from a generic layout property
+/// we want to do a convertion which may fail for two reasons:
+/// - A classic error as we want to read data (from value storage)
+/// - A invalid cast as we the layout property kind doesn't match the specific property kind
+///
+/// The former has to be forwarded transparently to (and by) the caller.
+/// The latter must be handled by the caller, probably has its own format error.
+//
+/// To do so, we want to impl `TryFrom` for an `Option<SpecificProperty>`. But trait cannot be
+/// implemented for foreign types, so we have to define our own "Option".
+/// We may define a new type `struct MayMatchType<T>(Option<T>)` and impl `TryFrom` to it,
+/// but we would need to export it as it would be part of the generic contract in `layout::Property::as_builder`.
+///
+/// So let's define a custom sealed "TryFrom"
+pub(crate) mod inner {
+    use super::{layout, Result, ValueStorageTrait};
+    pub trait FromLayoutProperty {
+        fn from_property(
+            p: &layout::Property,
+            value_storage: &impl ValueStorageTrait,
+        ) -> Result<Option<Self>>
+        where
+            Self: Sized;
+    }
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -89,15 +117,17 @@ impl IntProperty {
     }
 }
 
-impl<ValueStorage: ValueStorageTrait> TryFrom<(&layout::Property, &ValueStorage)> for IntProperty {
-    type Error = Error;
-    fn try_from(
-        p_vs: (&layout::Property, &ValueStorage),
-    ) -> std::result::Result<Self, Self::Error> {
-        let (p, value_storage) = p_vs;
-        match p.kind {
+impl FromLayoutProperty for IntProperty {
+    fn from_property(
+        p: &layout::Property,
+        value_storage: &impl ValueStorageTrait,
+    ) -> Result<Option<Self>>
+    where
+        Self: Sized,
+    {
+        Ok(match p.kind {
             PropertyKind::UnsignedInt { int_size, default } => {
-                Ok(IntProperty::new(p.offset, int_size, default, None))
+                Some(IntProperty::new(p.offset, int_size, default, None))
             }
             PropertyKind::DeportedUnsignedInt {
                 int_size,
@@ -105,12 +135,12 @@ impl<ValueStorage: ValueStorageTrait> TryFrom<(&layout::Property, &ValueStorage)
                 id,
             } => {
                 let store = value_storage.get_value_store(value_store_idx)?;
-                IntProperty::new_from_deported(p.offset, int_size, store, id)
+                Some(IntProperty::new_from_deported(
+                    p.offset, int_size, store, id,
+                )?)
             }
-            ref other => Err(Error::wrong_type(format!(
-                "Layout property {other:?} is not compatible with integer"
-            ))),
-        }
+            _ => None,
+        })
     }
 }
 
@@ -199,17 +229,17 @@ impl SignedProperty {
     }
 }
 
-impl<ValueStorage: ValueStorageTrait> TryFrom<(&layout::Property, &ValueStorage)>
-    for SignedProperty
-{
-    type Error = Error;
-    fn try_from(
-        p_vs: (&layout::Property, &ValueStorage),
-    ) -> std::result::Result<Self, Self::Error> {
-        let (p, value_storage) = p_vs;
-        match p.kind {
+impl FromLayoutProperty for SignedProperty {
+    fn from_property(
+        p: &layout::Property,
+        value_storage: &impl ValueStorageTrait,
+    ) -> Result<Option<Self>>
+    where
+        Self: Sized,
+    {
+        Ok(match p.kind {
             layout::PropertyKind::SignedInt { int_size, default } => {
-                Ok(SignedProperty::new(p.offset, int_size, default, None))
+                Some(SignedProperty::new(p.offset, int_size, default, None))
             }
             PropertyKind::DeportedSignedInt {
                 int_size,
@@ -217,12 +247,12 @@ impl<ValueStorage: ValueStorageTrait> TryFrom<(&layout::Property, &ValueStorage)
                 id,
             } => {
                 let store = value_storage.get_value_store(value_store_idx)?;
-                SignedProperty::new_from_deported(p.offset, int_size, store, id)
+                Some(SignedProperty::new_from_deported(
+                    p.offset, int_size, store, id,
+                )?)
             }
-            ref other => Err(Error::wrong_type(format!(
-                "Layout property {other:?} is not compatible with signed integer"
-            ))),
-        }
+            _ => None,
+        })
     }
 }
 
@@ -287,15 +317,15 @@ impl ArrayProperty {
     }
 }
 
-impl<ValueStorage: ValueStorageTrait> TryFrom<(&layout::Property, &ValueStorage)>
-    for ArrayProperty
-{
-    type Error = Error;
-    fn try_from(
-        p_vs: (&layout::Property, &ValueStorage),
-    ) -> std::result::Result<Self, Self::Error> {
-        let (p, value_storage) = p_vs;
-        match p.kind {
+impl FromLayoutProperty for ArrayProperty {
+    fn from_property(
+        p: &layout::Property,
+        value_storage: &impl ValueStorageTrait,
+    ) -> Result<Option<Self>>
+    where
+        Self: Sized,
+    {
+        Ok(match p.kind {
             layout::PropertyKind::Array {
                 array_len_size,
                 fixed_array_len,
@@ -312,7 +342,7 @@ impl<ValueStorage: ValueStorageTrait> TryFrom<(&layout::Property, &ValueStorage)
                         Some((id_size, value_store as Arc<dyn ValueStoreTrait>))
                     }
                 };
-                Ok(ArrayProperty::new(
+                Some(ArrayProperty::new(
                     p.offset,
                     array_len_size,
                     fixed_array_len,
@@ -320,10 +350,8 @@ impl<ValueStorage: ValueStorageTrait> TryFrom<(&layout::Property, &ValueStorage)
                     default,
                 ))
             }
-            ref other => Err(Error::wrong_type(format!(
-                "Layout property {other:?} is not compatible with array"
-            ))),
-        }
+            _ => None,
+        })
     }
 }
 
@@ -392,24 +420,27 @@ impl ContentProperty {
     }
 }
 
-impl TryFrom<&layout::Property> for ContentProperty {
-    type Error = Error;
-    fn try_from(p: &layout::Property) -> std::result::Result<Self, Self::Error> {
-        match p.kind {
+impl FromLayoutProperty for ContentProperty {
+    fn from_property(
+        p: &layout::Property,
+        _value_storage: &impl ValueStorageTrait,
+    ) -> Result<Option<Self>>
+    where
+        Self: Sized,
+    {
+        Ok(match p.kind {
             layout::PropertyKind::ContentAddress {
                 pack_id_size,
                 content_id_size,
                 default_pack_id,
-            } => Ok(ContentProperty::new(
+            } => Some(ContentProperty::new(
                 p.offset,
                 default_pack_id,
                 pack_id_size,
                 content_id_size,
             )),
-            ref other => Err(Error::wrong_type(format!(
-                "Layout property {other:?} is not compatible with content"
-            ))),
-        }
+            _ => None,
+        })
     }
 }
 
@@ -438,13 +469,15 @@ pub enum AnyProperty {
     Array(ArrayProperty),
 }
 
-impl<ValueStorage: ValueStorageTrait> TryFrom<(&layout::Property, &ValueStorage)> for AnyProperty {
-    type Error = Error;
-    fn try_from(
-        p_vs: (&layout::Property, &ValueStorage),
-    ) -> std::result::Result<Self, Self::Error> {
-        let (p, value_storage) = p_vs;
-        Ok(match &p.kind {
+impl FromLayoutProperty for AnyProperty {
+    fn from_property(
+        p: &layout::Property,
+        value_storage: &impl ValueStorageTrait,
+    ) -> Result<Option<Self>>
+    where
+        Self: Sized,
+    {
+        Ok(Some(match &p.kind {
             &PropertyKind::ContentAddress {
                 pack_id_size,
                 content_id_size,
@@ -507,7 +540,7 @@ impl<ValueStorage: ValueStorageTrait> TryFrom<(&layout::Property, &ValueStorage)
             }
             PropertyKind::Padding => unreachable!(),
             PropertyKind::VariantId => unreachable!(),
-        })
+        }))
     }
 }
 

--- a/src/reader/directory_pack/builder/property.rs
+++ b/src/reader/directory_pack/builder/property.rs
@@ -74,7 +74,9 @@ impl IntProperty {
                 let mut data_parser =
                     SliceParser::new(std::borrow::Cow::Borrowed(default_data), Offset::zero());
 
-                let default = data_parser.read_usized(size).unwrap();
+                let default = data_parser
+                    .read_usized(size)
+                    .expect("data_parser has the right size, so should not fail");
                 Ok(IntProperty::new(offset, size, Some(default), None))
             }
             DeportedDefault::KeySize(key_size) => Ok(IntProperty::new(
@@ -182,7 +184,9 @@ impl SignedProperty {
                 let mut data_parser =
                     SliceParser::new(std::borrow::Cow::Borrowed(default_data), Offset::zero());
 
-                let default = data_parser.read_isized(size).unwrap();
+                let default = data_parser
+                    .read_isized(size)
+                    .expect("data_parser has the right size, so should not fail");
                 Ok(SignedProperty::new(offset, size, Some(default), None))
             }
             DeportedDefault::KeySize(key_size) => Ok(SignedProperty::new(

--- a/src/reader/directory_pack/entry_store.rs
+++ b/src/reader/directory_pack/entry_store.rs
@@ -174,13 +174,13 @@ impl graphex::Node for PlainStore {
         use std::io::Read;
         let index = key
             .parse::<u32>()
-            .map_err(|e| Error::from(format!("{e}")))?;
+            .map_err(|e| graphex::Error::key(&format!("{e}")))?;
         let entry_reader = self.get_entry_reader(EntryIdx::from(index));
         let mut data = vec![];
         entry_reader
             .stream()
             .read_to_end(&mut data)
-            .map_err(Error::from)?;
+            .map_err(|e| graphex::Error::from(Error::from(e)))?;
         Ok(Box::new(data).into())
     }
 

--- a/src/reader/directory_pack/layout/mod.rs
+++ b/src/reader/directory_pack/layout/mod.rs
@@ -76,7 +76,7 @@ impl Parsable for Layout {
             common_size += raw_property.size;
             common_properties.push(raw_property);
         }
-        let common_properties = Properties::new(0, common_properties)?;
+        let common_properties = Properties::new(0, common_properties);
         let variant_part = if variant_count.into_u8() != 0 {
             let variant_id_offset = Offset::from(common_size);
             common_size += 1;
@@ -116,7 +116,7 @@ impl Parsable for Layout {
                         ))
                     }
                     Ordering::Equal => {
-                        variants.push(Properties::new(common_size, variant_def)?.into());
+                        variants.push(Properties::new(common_size, variant_def).into());
                         variants_map.insert(variant_name.unwrap(), variants.len() as u8 - 1);
                         variant_def = Vec::new();
                         variant_size = 0;

--- a/src/reader/directory_pack/layout/properties.rs
+++ b/src/reader/directory_pack/layout/properties.rs
@@ -1,6 +1,5 @@
 use super::super::raw_layout::{PropertyKind, RawProperty};
 use super::property::Property;
-use crate::bases::*;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -18,7 +17,7 @@ impl std::ops::Deref for Properties {
 }
 
 impl Properties {
-    pub(crate) fn new(initial_offset: usize, raw_properties: Vec<RawProperty>) -> Result<Self> {
+    pub(crate) fn new(initial_offset: usize, raw_properties: Vec<RawProperty>) -> Self {
         let mut offset = initial_offset;
         let mut properties = HashMap::new();
         for raw_property in raw_properties {
@@ -28,7 +27,7 @@ impl Properties {
                 properties.insert(raw_property.name.unwrap(), property);
             }
         }
-        Ok(Properties(properties))
+        Properties(properties)
     }
 }
 

--- a/src/reader/directory_pack/layout/property.rs
+++ b/src/reader/directory_pack/layout/property.rs
@@ -1,5 +1,8 @@
 use super::PropertyKind;
-use crate::bases::*;
+use crate::{
+    bases::*, reader::directory_pack::builder::inner::FromLayoutProperty,
+    reader::directory_pack::private::ValueStorageTrait,
+};
 
 /// The definition of a property, as we need to parse it.
 /// In opposition to RawProperty, the property is the "final" property.
@@ -17,6 +20,14 @@ impl Property {
             offset: Offset::from(offset),
             kind,
         }
+    }
+
+    pub fn as_builder<B, ValueStorage>(&self, value_storage: &ValueStorage) -> Result<Option<B>>
+    where
+        ValueStorage: ValueStorageTrait,
+        B: FromLayoutProperty,
+    {
+        B::from_property(self, value_storage)
     }
 }
 

--- a/src/reader/directory_pack/mod.rs
+++ b/src/reader/directory_pack/mod.rs
@@ -145,6 +145,7 @@ impl DirectoryPack {
 }
 
 impl CachableSource<ValueStore> for DirectoryPack {
+    type Error = Error;
     type Idx = ValueStoreIdx;
     fn get_len(&self) -> usize {
         self.header.value_store_count.into_usize()
@@ -159,6 +160,7 @@ impl CachableSource<ValueStore> for DirectoryPack {
 }
 
 impl CachableSource<EntryStore> for DirectoryPack {
+    type Error = Error;
     type Idx = EntryStoreIdx;
     fn get_len(&self) -> usize {
         self.header.entry_store_count.into_usize()
@@ -205,11 +207,12 @@ impl Pack for DirectoryPack {
             Size::from(self.pack_header.check_info_pos),
             false,
         )?;
-        self.check_info
+        Ok(self
+            .check_info
             .read()
             .unwrap()
             .unwrap()
-            .check(&mut check_stream)
+            .check(&mut check_stream)?)
     }
 }
 

--- a/src/reader/directory_pack/mod.rs
+++ b/src/reader/directory_pack/mod.rs
@@ -121,7 +121,7 @@ impl DirectoryPack {
         Ok(index)
     }
 
-    pub fn get_index_from_name(&self, index_name: &str) -> Result<Index> {
+    pub fn get_index_from_name(&self, index_name: &str) -> Result<Option<Index>> {
         for index_id in self.header.index_count {
             let sized_offset = self.index_ptrs.index(*index_id)?;
             let index_header = self
@@ -129,10 +129,10 @@ impl DirectoryPack {
                 .parse_block_in::<IndexHeader>(sized_offset.offset, sized_offset.size)?;
             if index_header.name == index_name {
                 let index = Index::new(index_header);
-                return Ok(index);
+                return Ok(Some(index));
             }
         }
-        Err(Error::notfound(format!("Cannot find index {index_name}")))
+        Ok(None)
     }
 
     pub fn create_value_storage(self: &Arc<Self>) -> Arc<ValueStorage> {
@@ -359,7 +359,9 @@ impl graphex::Node for DirectoryPack {
             let index = if let Ok(index) = item.parse::<u32>() {
                 EntryStoreIdx::from(index)
             } else {
-                let index = self.get_index_from_name(item)?;
+                let index = self.get_index_from_name(item)?.ok_or_else(|| {
+                    graphex::Error::key(&format!("Key {item} not found in directory pack."))
+                })?;
                 index.get_store_id()
             };
             let sized_offset = self.entry_stores_ptrs.index(*index)?;
@@ -434,7 +436,7 @@ mod tests {
     }
 
     #[test]
-    fn test_directorypack() {
+    fn test_directorypack() -> Result<()> {
         // Pack header offset 0/0x00
         let mut content = vec![
             0x6a, 0x62, 0x6b, 0x64, // magic
@@ -556,21 +558,18 @@ mod tests {
 
         // File size 366 + 64 = 430/0x1AE (file_size)
 
-        let directory_pack = Arc::new(DirectoryPack::new(content.into()).unwrap());
-        assert!(directory_pack.check().unwrap());
-        let index = directory_pack.get_index(0.into()).unwrap();
+        let directory_pack = Arc::new(DirectoryPack::new(content.into())?);
+        assert!(directory_pack.check()?);
+        let index = directory_pack.get_index(0.into())?;
         let value_storage = directory_pack.create_value_storage();
         let entry_storage = directory_pack.create_entry_storage();
-        let builder = builder::AnyBuilder::new(
-            index.get_store(&entry_storage).unwrap(),
-            value_storage.as_ref(),
-        )
-        .unwrap();
+        let builder =
+            builder::AnyBuilder::new(index.get_store(&entry_storage)?, value_storage.as_ref())?;
         assert_eq!(index.count(), 4.into());
         {
-            let entry = index.get_entry(&builder, 0.into()).unwrap();
-            assert_eq!(entry.get_variant_id().unwrap(), None);
-            let value0 = entry.get_value("A").unwrap();
+            let entry = index.get_entry(&builder, 0.into())?.unwrap();
+            assert_eq!(entry.get_variant_id()?, None);
+            let value0 = entry.get_value("A")?;
             if let Some(RawValue::Array(a)) = &value0 {
                 assert_eq!(
                     &FakeArray::new(
@@ -585,10 +584,10 @@ mod tests {
                 panic!("Must be a array");
             };
             assert_eq!(
-                value0.unwrap().as_vec().unwrap(),
+                value0.unwrap().as_vec()?,
                 b"J\xc5\xabbako" // Jūbako
             );
-            let value1 = entry.get_value("B").unwrap();
+            let value1 = entry.get_value("B")?;
             if let Some(RawValue::Array(a)) = &value1 {
                 assert_eq!(
                     &FakeArray::new(
@@ -602,10 +601,10 @@ mod tests {
             } else {
                 panic!("Must be a array");
             };
-            assert_eq!(value1.unwrap().as_vec().unwrap(), b"aBHello");
-            assert_eq!(entry.get_value("C").unwrap(), Some(RawValue::U32(0x212223)));
+            assert_eq!(value1.unwrap().as_vec()?, b"aBHello");
+            assert_eq!(entry.get_value("C")?, Some(RawValue::U32(0x212223)));
             assert_eq!(
-                entry.get_value("D").unwrap(),
+                entry.get_value("D")?,
                 Some(RawValue::Content(ContentAddress {
                     pack_id: PackId::from(1),
                     content_id: ContentIdx::from(0)
@@ -613,9 +612,9 @@ mod tests {
             );
         }
         {
-            let entry = index.get_entry(&builder, 1.into()).unwrap();
-            assert_eq!(entry.get_variant_id().unwrap(), None);
-            let value0 = entry.get_value("A").unwrap();
+            let entry = index.get_entry(&builder, 1.into())?.unwrap();
+            assert_eq!(entry.get_variant_id()?, None);
+            let value0 = entry.get_value("A")?;
             if let Some(RawValue::Array(a)) = &value0 {
                 assert_eq!(
                     &FakeArray::new(
@@ -629,8 +628,8 @@ mod tests {
             } else {
                 panic!("Must be a array");
             };
-            assert_eq!(value0.unwrap().as_vec().unwrap(), b"Foo");
-            let value1 = entry.get_value("B").unwrap();
+            assert_eq!(value0.unwrap().as_vec()?, b"Foo");
+            let value1 = entry.get_value("B")?;
             if let Some(RawValue::Array(a)) = &value1 {
                 assert_eq!(
                     &FakeArray::new(
@@ -644,10 +643,10 @@ mod tests {
             } else {
                 panic!("Must be a array");
             };
-            assert_eq!(value1.unwrap().as_vec().unwrap(), b"ABJ\xc5\xabbako");
-            assert_eq!(entry.get_value("C").unwrap(), Some(RawValue::U32(0x313233)));
+            assert_eq!(value1.unwrap().as_vec()?, b"ABJ\xc5\xabbako");
+            assert_eq!(entry.get_value("C")?, Some(RawValue::U32(0x313233)));
             assert_eq!(
-                entry.get_value("D").unwrap(),
+                entry.get_value("D")?,
                 Some(RawValue::Content(ContentAddress {
                     pack_id: PackId::from(0),
                     content_id: ContentIdx::from(1)
@@ -655,9 +654,9 @@ mod tests {
             );
         }
         {
-            let entry = index.get_entry(&builder, 2.into()).unwrap();
-            assert_eq!(entry.get_variant_id().unwrap(), None);
-            let value0 = entry.get_value("A").unwrap();
+            let entry = index.get_entry(&builder, 2.into())?.unwrap();
+            assert_eq!(entry.get_variant_id()?, None);
+            let value0 = entry.get_value("A")?;
             if let Some(RawValue::Array(a)) = &value0 {
                 assert_eq!(
                     &FakeArray::new(
@@ -671,8 +670,8 @@ mod tests {
             } else {
                 panic!("Must be a array");
             };
-            assert_eq!(value0.unwrap().as_vec().unwrap(), b"J\xc5\xabbako");
-            let value1 = entry.get_value("B").unwrap();
+            assert_eq!(value0.unwrap().as_vec()?, b"J\xc5\xabbako");
+            let value1 = entry.get_value("B")?;
             if let Some(RawValue::Array(a)) = &value1 {
                 assert_eq!(
                     &FakeArray::new(
@@ -686,10 +685,10 @@ mod tests {
             } else {
                 panic!("Must be a array");
             };
-            assert_eq!(value1.unwrap().as_vec().unwrap(), b"ABFoo");
-            assert_eq!(entry.get_value("C").unwrap(), Some(RawValue::U32(0x414243)));
+            assert_eq!(value1.unwrap().as_vec()?, b"ABFoo");
+            assert_eq!(entry.get_value("C")?, Some(RawValue::U32(0x414243)));
             assert_eq!(
-                entry.get_value("D").unwrap(),
+                entry.get_value("D")?,
                 Some(RawValue::Content(ContentAddress {
                     pack_id: PackId::from(0),
                     content_id: ContentIdx::from(2)
@@ -697,9 +696,9 @@ mod tests {
             );
         }
         {
-            let entry = index.get_entry(&builder, 3.into()).unwrap();
-            assert_eq!(entry.get_variant_id().unwrap(), None);
-            let value0 = entry.get_value("A").unwrap();
+            let entry = index.get_entry(&builder, 3.into())?.unwrap();
+            assert_eq!(entry.get_variant_id()?, None);
+            let value0 = entry.get_value("A")?;
             if let Some(RawValue::Array(a)) = &value0 {
                 assert_eq!(
                     &FakeArray::new(
@@ -713,8 +712,8 @@ mod tests {
             } else {
                 panic!("Must be a array");
             };
-            assert_eq!(value0.unwrap().as_vec().unwrap(), b"Hello");
-            let value1 = entry.get_value("B").unwrap();
+            assert_eq!(value0.unwrap().as_vec()?, b"Hello");
+            let value1 = entry.get_value("B")?;
             if let Some(RawValue::Array(a)) = &value1 {
                 assert_eq!(
                     &FakeArray::new(
@@ -728,15 +727,16 @@ mod tests {
             } else {
                 panic!("Must be a array");
             };
-            assert_eq!(value1.unwrap().as_vec().unwrap(), b"\0\0Foo");
-            assert_eq!(entry.get_value("C").unwrap(), Some(RawValue::U32(0x515253)));
+            assert_eq!(value1.unwrap().as_vec()?, b"\0\0Foo");
+            assert_eq!(entry.get_value("C")?, Some(RawValue::U32(0x515253)));
             assert_eq!(
-                entry.get_value("D").unwrap(),
+                entry.get_value("D")?,
                 Some(RawValue::Content(ContentAddress {
                     pack_id: PackId::from(0),
                     content_id: ContentIdx::from(0xaaaaaa)
                 }))
             );
         }
+        Ok(())
     }
 }

--- a/src/reader/directory_pack/mod.rs
+++ b/src/reader/directory_pack/mod.rs
@@ -24,7 +24,7 @@ pub use raw_value::RawValue;
 
 pub trait EntryTrait {
     fn get_variant_id(&self) -> Result<Option<VariantIdx>>;
-    fn get_value(&self, name: &str) -> Result<RawValue>;
+    fn get_value(&self, name: &str) -> Result<Option<RawValue>>;
 }
 
 mod private {
@@ -132,7 +132,7 @@ impl DirectoryPack {
                 return Ok(index);
             }
         }
-        Err(format!("Cannot find index {index_name}").into())
+        Err(Error::notfound(format!("Cannot find index {index_name}")))
     }
 
     pub fn create_value_storage(self: &Arc<Self>) -> Arc<ValueStorage> {
@@ -568,7 +568,7 @@ mod tests {
             let entry = index.get_entry(&builder, 0.into()).unwrap();
             assert_eq!(entry.get_variant_id().unwrap(), None);
             let value0 = entry.get_value("A").unwrap();
-            if let RawValue::Array(a) = &value0 {
+            if let Some(RawValue::Array(a)) = &value0 {
                 assert_eq!(
                     &FakeArray::new(
                         Some(ASize::new(7)),
@@ -582,11 +582,11 @@ mod tests {
                 panic!("Must be a array");
             };
             assert_eq!(
-                value0.as_vec().unwrap(),
+                value0.unwrap().as_vec().unwrap(),
                 b"J\xc5\xabbako" // Jūbako
             );
             let value1 = entry.get_value("B").unwrap();
-            if let RawValue::Array(a) = &value1 {
+            if let Some(RawValue::Array(a)) = &value1 {
                 assert_eq!(
                     &FakeArray::new(
                         Some(ASize::new(7)),
@@ -599,21 +599,21 @@ mod tests {
             } else {
                 panic!("Must be a array");
             };
-            assert_eq!(value1.as_vec().unwrap(), b"aBHello");
-            assert_eq!(entry.get_value("C").unwrap(), RawValue::U32(0x212223));
+            assert_eq!(value1.unwrap().as_vec().unwrap(), b"aBHello");
+            assert_eq!(entry.get_value("C").unwrap(), Some(RawValue::U32(0x212223)));
             assert_eq!(
                 entry.get_value("D").unwrap(),
-                RawValue::Content(ContentAddress {
+                Some(RawValue::Content(ContentAddress {
                     pack_id: PackId::from(1),
                     content_id: ContentIdx::from(0)
-                })
+                }))
             );
         }
         {
             let entry = index.get_entry(&builder, 1.into()).unwrap();
             assert_eq!(entry.get_variant_id().unwrap(), None);
             let value0 = entry.get_value("A").unwrap();
-            if let RawValue::Array(a) = &value0 {
+            if let Some(RawValue::Array(a)) = &value0 {
                 assert_eq!(
                     &FakeArray::new(
                         Some(ASize::new(3)),
@@ -626,9 +626,9 @@ mod tests {
             } else {
                 panic!("Must be a array");
             };
-            assert_eq!(value0.as_vec().unwrap(), b"Foo");
+            assert_eq!(value0.unwrap().as_vec().unwrap(), b"Foo");
             let value1 = entry.get_value("B").unwrap();
-            if let RawValue::Array(a) = &value1 {
+            if let Some(RawValue::Array(a)) = &value1 {
                 assert_eq!(
                     &FakeArray::new(
                         Some(ASize::new(9)),
@@ -641,21 +641,21 @@ mod tests {
             } else {
                 panic!("Must be a array");
             };
-            assert_eq!(value1.as_vec().unwrap(), b"ABJ\xc5\xabbako");
-            assert_eq!(entry.get_value("C").unwrap(), RawValue::U32(0x313233));
+            assert_eq!(value1.unwrap().as_vec().unwrap(), b"ABJ\xc5\xabbako");
+            assert_eq!(entry.get_value("C").unwrap(), Some(RawValue::U32(0x313233)));
             assert_eq!(
                 entry.get_value("D").unwrap(),
-                RawValue::Content(ContentAddress {
+                Some(RawValue::Content(ContentAddress {
                     pack_id: PackId::from(0),
                     content_id: ContentIdx::from(1)
-                })
+                }))
             );
         }
         {
             let entry = index.get_entry(&builder, 2.into()).unwrap();
             assert_eq!(entry.get_variant_id().unwrap(), None);
             let value0 = entry.get_value("A").unwrap();
-            if let RawValue::Array(a) = &value0 {
+            if let Some(RawValue::Array(a)) = &value0 {
                 assert_eq!(
                     &FakeArray::new(
                         Some(ASize::new(7)),
@@ -668,9 +668,9 @@ mod tests {
             } else {
                 panic!("Must be a array");
             };
-            assert_eq!(value0.as_vec().unwrap(), b"J\xc5\xabbako");
+            assert_eq!(value0.unwrap().as_vec().unwrap(), b"J\xc5\xabbako");
             let value1 = entry.get_value("B").unwrap();
-            if let RawValue::Array(a) = &value1 {
+            if let Some(RawValue::Array(a)) = &value1 {
                 assert_eq!(
                     &FakeArray::new(
                         Some(ASize::new(5)),
@@ -683,21 +683,21 @@ mod tests {
             } else {
                 panic!("Must be a array");
             };
-            assert_eq!(value1.as_vec().unwrap(), b"ABFoo");
-            assert_eq!(entry.get_value("C").unwrap(), RawValue::U32(0x414243));
+            assert_eq!(value1.unwrap().as_vec().unwrap(), b"ABFoo");
+            assert_eq!(entry.get_value("C").unwrap(), Some(RawValue::U32(0x414243)));
             assert_eq!(
                 entry.get_value("D").unwrap(),
-                RawValue::Content(ContentAddress {
+                Some(RawValue::Content(ContentAddress {
                     pack_id: PackId::from(0),
                     content_id: ContentIdx::from(2)
-                })
+                }))
             );
         }
         {
             let entry = index.get_entry(&builder, 3.into()).unwrap();
             assert_eq!(entry.get_variant_id().unwrap(), None);
             let value0 = entry.get_value("A").unwrap();
-            if let RawValue::Array(a) = &value0 {
+            if let Some(RawValue::Array(a)) = &value0 {
                 assert_eq!(
                     &FakeArray::new(
                         Some(ASize::new(5)),
@@ -710,9 +710,9 @@ mod tests {
             } else {
                 panic!("Must be a array");
             };
-            assert_eq!(value0.as_vec().unwrap(), b"Hello");
+            assert_eq!(value0.unwrap().as_vec().unwrap(), b"Hello");
             let value1 = entry.get_value("B").unwrap();
-            if let RawValue::Array(a) = &value1 {
+            if let Some(RawValue::Array(a)) = &value1 {
                 assert_eq!(
                     &FakeArray::new(
                         Some(ASize::new(5)),
@@ -725,14 +725,14 @@ mod tests {
             } else {
                 panic!("Must be a array");
             };
-            assert_eq!(value1.as_vec().unwrap(), b"\0\0Foo");
-            assert_eq!(entry.get_value("C").unwrap(), RawValue::U32(0x515253));
+            assert_eq!(value1.unwrap().as_vec().unwrap(), b"\0\0Foo");
+            assert_eq!(entry.get_value("C").unwrap(), Some(RawValue::U32(0x515253)));
             assert_eq!(
                 entry.get_value("D").unwrap(),
-                RawValue::Content(ContentAddress {
+                Some(RawValue::Content(ContentAddress {
                     pack_id: PackId::from(0),
                     content_id: ContentIdx::from(0xaaaaaa)
-                })
+                }))
             );
         }
     }

--- a/src/reader/directory_pack/mod.rs
+++ b/src/reader/directory_pack/mod.rs
@@ -367,7 +367,7 @@ impl graphex::Node for DirectoryPack {
         } else if let Some(item) = key.strip_prefix("v.") {
             let index = item
                 .parse::<u8>()
-                .map_err(|e| Error::from(format!("{e}")))?;
+                .map_err(|e| graphex::Error::key(&format!("{e}")))?;
             let sized_offset = self.value_stores_ptrs.index(index.into())?;
             Ok(Box::new(self.reader.parse_data_block::<ValueStore>(sized_offset)?).into())
         } else {

--- a/src/reader/directory_pack/property_compare.rs
+++ b/src/reader/directory_pack/property_compare.rs
@@ -30,7 +30,10 @@ impl<'builder> PropertyCompare<'builder> {
 
 impl CompareTrait for PropertyCompare<'_> {
     fn compare_entry(&self, idx: EntryIdx) -> Result<Ordering> {
-        let entry = self.builder.create_entry(idx)?;
+        let entry = self
+            .builder
+            .create_entry(idx)?
+            .expect("idx is valid as `compare_entry` is piloted by a range looping on its entries");
         for (name, value) in std::iter::zip(self.property_names.iter(), self.values.iter()) {
             let ordering = entry
                 .get_value(name)?

--- a/src/reader/directory_pack/property_compare.rs
+++ b/src/reader/directory_pack/property_compare.rs
@@ -34,8 +34,9 @@ impl CompareTrait for PropertyCompare<'_> {
         for (name, value) in std::iter::zip(self.property_names.iter(), self.values.iter()) {
             let ordering = entry
                 .get_value(name)?
+                .ok_or_else(|| Error::arg(format!("Invalid name {name}")))?
                 .partial_cmp(value)?
-                .ok_or_else(|| Error::from("Invalide value type".to_string()))?;
+                .ok_or_else(|| Error::arg(format!("Invalid value type {value:?}")))?;
             if ordering.is_ne() {
                 return Ok(ordering);
             }

--- a/src/reader/directory_pack/property_compare.rs
+++ b/src/reader/directory_pack/property_compare.rs
@@ -37,9 +37,9 @@ impl CompareTrait for PropertyCompare<'_> {
         for (name, value) in std::iter::zip(self.property_names.iter(), self.values.iter()) {
             let ordering = entry
                 .get_value(name)?
-                .ok_or_else(|| Error::arg(format!("Invalid name {name}")))?
+                .expect("Name should be in the entry")
                 .partial_cmp(value)?
-                .ok_or_else(|| Error::arg(format!("Invalid value type {value:?}")))?;
+                .expect("Value in the entry correspond to reference value");
             if ordering.is_ne() {
                 return Ok(ordering);
             }

--- a/src/reader/directory_pack/range.rs
+++ b/src/reader/directory_pack/range.rs
@@ -19,7 +19,7 @@ pub trait RangeTrait {
         if id.is_valid(*self.count()) {
             builder.create_entry(self.offset() + id)
         } else {
-            Err("Invalid id".to_string().into())
+            Err(Error::notfound("Invalid id"))
         }
     }
 
@@ -103,11 +103,11 @@ mod tests {
             fn get_variant_id(&self) -> Result<Option<VariantIdx>> {
                 Ok(None)
             }
-            fn get_value(&self, name: &str) -> Result<RawValue> {
+            fn get_value(&self, name: &str) -> Result<Option<RawValue>> {
                 if name == "foo" {
-                    Ok(self.v.clone())
+                    Ok(Some(self.v.clone()))
                 } else {
-                    panic!()
+                    Ok(None)
                 }
             }
         }
@@ -165,7 +165,7 @@ mod tests {
 
         for i in 0..10 {
             let entry = range.get_entry(&builder, i.into()).unwrap();
-            let value0 = entry.get_value("foo").unwrap();
+            let value0 = entry.get_value("foo").unwrap().unwrap();
             assert_eq!(value0.as_unsigned(), i as u64);
         }
     }
@@ -179,7 +179,7 @@ mod tests {
             let comparator = mock::EntryCompare::new(i, false);
             let idx = range.find(&comparator).unwrap().unwrap();
             let entry = range.get_entry(&builder, idx).unwrap();
-            let value0 = entry.get_value("foo").unwrap();
+            let value0 = entry.get_value("foo").unwrap().unwrap();
             assert_eq!(value0.as_unsigned(), i as u64);
         }
 
@@ -197,7 +197,7 @@ mod tests {
             let comparator = mock::EntryCompare::new(i, true);
             let idx = range.find(&comparator).unwrap().unwrap();
             let entry = range.get_entry(&builder, idx).unwrap();
-            let value0 = entry.get_value("foo").unwrap();
+            let value0 = entry.get_value("foo").unwrap().unwrap();
             assert_eq!(value0.as_unsigned(), i as u64);
         }
 

--- a/src/reader/directory_pack/range.rs
+++ b/src/reader/directory_pack/range.rs
@@ -15,7 +15,7 @@ pub trait RangeTrait {
         &self,
         builder: &Builder,
         id: EntryIdx,
-    ) -> Result<Option<Builder::Entry>> {
+    ) -> std::result::Result<Option<Builder::Entry>, Builder::Error> {
         if id.is_valid(*self.count()) {
             builder.create_entry(self.offset() + id)
         } else {
@@ -136,6 +136,7 @@ mod tests {
         pub struct Builder {}
         impl builder::BuilderTrait for Builder {
             type Entry = Entry;
+            type Error = Error;
             fn create_entry(&self, idx: EntryIdx) -> Result<Option<Self::Entry>> {
                 Ok(Some(Entry::new(idx.into_u32() as u16)))
             }

--- a/src/reader/directory_pack/raw_layout.rs
+++ b/src/reader/directory_pack/raw_layout.rs
@@ -298,6 +298,7 @@ impl Parsable for RawLayout {
 }
 
 #[cfg(test)]
+#[allow(clippy::identity_op)]
 mod tests {
     use super::*;
     use test_case::test_case;

--- a/src/reader/directory_pack/raw_layout.rs
+++ b/src/reader/directory_pack/raw_layout.rs
@@ -84,8 +84,7 @@ impl Parsable for RawProperty {
     type Output = Self;
     fn parse(parser: &mut impl Parser) -> Result<Self> {
         let propinfo = parser.read_u8()?;
-        let proptype = PropType::try_from(propinfo & 0xF0)
-            .map_err::<Error, _>(|e| format_error!(&e, parser))?;
+        let proptype = PropType::try_from(propinfo & 0xF0)?;
         let propdata = propinfo & 0x0F;
         let (propsize, kind, name) = match proptype {
             PropType::Padding => (propdata as u16 + 1, PropertyKind::Padding, None),

--- a/src/reader/directory_pack/value_store.rs
+++ b/src/reader/directory_pack/value_store.rs
@@ -317,21 +317,21 @@ impl graphex::Node for IndexedValueStore {
         let (idx, size) = if let Some((first, second)) = key.split_once('-') {
             let offset = first
                 .parse::<u64>()
-                .map_err(|e| Error::from(format!("{e}")))?;
+                .map_err(|e| graphex::Error::key(&format!("{e}")))?;
             let size = Some(ASize::from(
                 second
                     .parse::<usize>()
-                    .map_err(|e| Error::from(format!("{e}")))?,
+                    .map_err(|e| graphex::Error::key(&format!("{e}")))?,
             ));
             (offset, size)
         } else {
             let offset = key
                 .parse::<u64>()
-                .map_err(|e| Error::from(format!("{e}")))?;
+                .map_err(|e| graphex::Error::key(&format!("{e}")))?;
             (offset, None)
         };
         if idx >= self.value_offsets.len() as u64 {
-            return Err(Error::from(format!("{idx} is not a valid index")).into());
+            return Err(graphex::Error::key(&format!("{idx} is not a valid index")));
         }
         Ok(Box::new(
             String::from_utf8_lossy(self.get_data(ValueIdx::from(idx), size)?).into_owned(),

--- a/src/reader/jubako.rs
+++ b/src/reader/jubako.rs
@@ -90,7 +90,7 @@ impl Container {
         let reader = container_pack.get_manifest_pack_reader()?;
 
         if reader.is_none() {
-            return Err(Error::notfound("Impossible to locate the manifest_pack"));
+            return Err(format_error!("Impossible to locate the manifest_pack"));
         }
         let reader = reader.unwrap();
 
@@ -173,7 +173,7 @@ impl Container {
     }
 
     /// Get a index by its name
-    pub fn get_index_for_name(&self, name: &str) -> Result<Index> {
+    pub fn get_index_for_name(&self, name: &str) -> Result<Option<Index>> {
         self.directory_pack.get_index_from_name(name)
     }
 

--- a/src/reader/jubako.rs
+++ b/src/reader/jubako.rs
@@ -90,7 +90,7 @@ impl Container {
         let reader = container_pack.get_manifest_pack_reader()?;
 
         if reader.is_none() {
-            return Err("Impossible to locate the manifest_pack".into());
+            return Err(Error::notfound("Impossible to locate the manifest_pack"));
         }
         let reader = reader.unwrap();
 

--- a/src/reader/locator.rs
+++ b/src/reader/locator.rs
@@ -1,6 +1,5 @@
 use crate::bases::*;
-use bstr::ByteSlice;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -22,7 +21,7 @@ impl FsLocator {
 
 impl PackLocatorTrait for FsLocator {
     fn locate(&self, _uuid: Uuid, path: &[u8]) -> Result<Option<Reader>> {
-        let path = Path::new(path.to_path()?);
+        let path: PathBuf = String::from_utf8(path.to_vec())?.into();
         let path = self.base_dir.join(path);
         if path.is_file() {
             Ok(Some(Reader::from(FileSource::open(path)?)))

--- a/src/reader/manifest_pack.rs
+++ b/src/reader/manifest_pack.rs
@@ -212,7 +212,7 @@ impl Pack for ManifestPack {
         )?;
         let mut check_stream =
             ManifestCheckStream::new_from_offset_iter(&mut check_stream, self.packs_offset());
-        check_info.check(&mut check_stream)
+        Ok(check_info.check(&mut check_stream)?)
     }
 }
 

--- a/src/reader/manifest_pack.rs
+++ b/src/reader/manifest_pack.rs
@@ -138,7 +138,7 @@ impl ManifestPack {
                 return Ok(pack_info);
             }
         }
-        Err(Error::new_arg())
+        Err(Error::arg(format!("Invalid pack_id {pack_id}")))
     }
 
     pub fn get_content_pack_info_uuid(&self, uuid: Uuid) -> Result<&PackInfo> {
@@ -147,7 +147,7 @@ impl ManifestPack {
                 return Ok(pack_info);
             }
         }
-        Err(Error::new_arg())
+        Err(Error::arg(format!("Invalid uuid {uuid}")))
     }
 
     pub fn get_pack_infos(&self) -> &[PackInfo] {

--- a/src/reader/missing.rs
+++ b/src/reader/missing.rs
@@ -46,9 +46,19 @@ impl<T, E> MayMissPack<Result<T, E>> {
     #[inline]
     pub fn transpose(self) -> Result<MayMissPack<T>, E> {
         match self {
-            Self::FOUND(Ok(x)) => Ok(MayMissPack::FOUND(x)),
             Self::FOUND(Err(e)) => Err(e),
+            Self::FOUND(Ok(x)) => Ok(MayMissPack::FOUND(x)),
             Self::MISSING(pack_info) => Ok(MayMissPack::MISSING(pack_info)),
+        }
+    }
+}
+
+impl<T> MayMissPack<Option<T>> {
+    pub fn transpose(self) -> Option<MayMissPack<T>> {
+        match self {
+            Self::FOUND(None) => None,
+            Self::FOUND(Some(x)) => Some(MayMissPack::FOUND(x)),
+            Self::MISSING(pack_info) => Some(MayMissPack::MISSING(pack_info)),
         }
     }
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -38,12 +38,12 @@ pub fn set_location<P: AsRef<Path>>(
     filename: P,
     uuid: Uuid,
     new_location: Vec<u8>,
-) -> jbk::Result<(PackKind, Vec<u8>)> {
+) -> jbk::Result<Option<(PackKind, Vec<u8>)>> {
     let container = Arc::new(jbk::tools::open_pack(&filename)?);
 
     let manifest_pack_reader = container.get_manifest_pack_reader()?;
     if manifest_pack_reader.is_none() {
-        return Err(Error::notfound(format!(
+        return Err(format_error!(format!(
             "No manifest pack in {}",
             filename.as_ref().display()
         )));
@@ -72,7 +72,7 @@ pub fn set_location<P: AsRef<Path>>(
         file.seek(SeekFrom::Start(global_pack_offset))?;
         file.ser_write(&pack_info)?;
 
-        return Ok((pack_info.pack_kind, old_location));
+        return Ok(Some((pack_info.pack_kind, old_location)));
     }
-    Err(Error::notfound(format!("Cannot find pack {uuid}")))
+    Ok(None)
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -43,7 +43,10 @@ pub fn set_location<P: AsRef<Path>>(
 
     let manifest_pack_reader = container.get_manifest_pack_reader()?;
     if manifest_pack_reader.is_none() {
-        return Err(format!("No manifest pack in {}", filename.as_ref().display()).into());
+        return Err(Error::notfound(format!(
+            "No manifest pack in {}",
+            filename.as_ref().display()
+        )));
     };
     let manifest_pack_reader = manifest_pack_reader.unwrap();
     let pack_header = manifest_pack_reader.parse_block_at::<PackHeader>(jbk::Offset::zero())?;
@@ -71,5 +74,5 @@ pub fn set_location<P: AsRef<Path>>(
 
         return Ok((pack_info.pack_kind, old_location));
     }
-    Err(format!("Cannot find pack {uuid}").into())
+    Err(Error::notfound(format!("Cannot find pack {uuid}")))
 }

--- a/tests/creator_jubako.rs
+++ b/tests/creator_jubako.rs
@@ -224,7 +224,7 @@ test_suite! {
             println!("Get reader");
             let bytes = container.get_bytes(value_1).unwrap();
             println!("Readir is {:?}", bytes);
-            let mut stream = bytes.expect("value_1 has a valid pack_id").unwrap().expect("value_1 has a valid content_id").stream();
+            let mut stream = bytes.and_then(|m| m.transpose()).expect("value_1 should be valid").unwrap().stream();
             let mut read_content: String = "".to_string();
             println!("Read from stream");
             stream.read_to_string(&mut read_content).unwrap();

--- a/tests/creator_jubako.rs
+++ b/tests/creator_jubako.rs
@@ -213,12 +213,12 @@ test_suite! {
             let entry = index.get_entry(&builder, i).unwrap();
             assert_eq!(entry.get_variant_id().unwrap(), None);
             println!("Check value 0");
-            let value_0 = entry.get_value("V0").unwrap();
+            let value_0 = entry.get_value("V0").unwrap().unwrap();
             println!("Raw value 0 is {:?}", value_0);
             let value_0 = value_0.as_vec().unwrap();
             assert_eq!(value_0, articles.val[i.into_usize()].path.as_bytes());
             println!("Check value 1");
-            let value_1 = entry.get_value("V1").unwrap();
+            let value_1 = entry.get_value("V1").unwrap().unwrap();
             println!("Raw value 1 is {:?}", value_1);
             let value_1 = value_1.as_content();
             println!("Value 1 is {:?}", value_1);
@@ -231,7 +231,7 @@ test_suite! {
             stream.read_to_string(&mut read_content).unwrap();
             assert_eq!(read_content, articles.val[i.into_usize()].content);
             println!("Check value 2");
-            let value_2 = entry.get_value("V2").unwrap();
+            let value_2 = entry.get_value("V2").unwrap().unwrap();
             let value_2 = value_2.as_unsigned();
             assert_eq!(value_2, articles.val[i.into_usize()].word_count as u64);
         }

--- a/tests/creator_jubako.rs
+++ b/tests/creator_jubako.rs
@@ -224,7 +224,7 @@ test_suite! {
             println!("Get reader");
             let bytes = container.get_bytes(value_1).unwrap();
             println!("Readir is {:?}", bytes);
-            let mut stream = bytes.as_ref().unwrap().stream();
+            let mut stream = bytes.expect("value_1 has a valid pack_id").unwrap().expect("value_1 has a valid content_id").stream();
             let mut read_content: String = "".to_string();
             println!("Read from stream");
             stream.read_to_string(&mut read_content).unwrap();

--- a/tests/creator_jubako.rs
+++ b/tests/creator_jubako.rs
@@ -10,8 +10,7 @@ test_suite! {
     name basic_creation;
 
     use jubako::creator;
-    use jubako::creator::schema;
-    use jubako::Result;
+    use jubako::creator::{schema, Result};
     use jubako::reader::{Range, EntryTrait};
     use std::io::{Read, Seek};
     use crate::Entry as TestEntry;

--- a/tests/creator_jubako.rs
+++ b/tests/creator_jubako.rs
@@ -209,7 +209,7 @@ test_suite! {
         assert_eq!(index.count(), (articles.val.len() as u32).into());
         for i in index.count() {
             println!("Check entry count {:?}", i);
-            let entry = index.get_entry(&builder, i).unwrap();
+            let entry = index.get_entry(&builder, i).unwrap().expect("Entry i is in the index");
             assert_eq!(entry.get_variant_id().unwrap(), None);
             println!("Check value 0");
             let value_0 = entry.get_value("V0").unwrap().unwrap();

--- a/tests/jubako.rs
+++ b/tests/jubako.rs
@@ -648,14 +648,14 @@ test_suite! {
         let container = reader::Container::new(main_path).unwrap();
         assert_eq!(container.pack_count(), 2.into());
         assert!(container.check().unwrap());
-        let index = container.get_index_for_name("Super index").unwrap();
+        let index = container.get_index_for_name("Super index").unwrap().expect("'Super index' is in the container");
         let builder = reader::builder::AnyBuilder::new(
             index.get_store(container.get_entry_storage()).unwrap(),
             container.get_value_storage().as_ref()
         ).unwrap();
         assert_eq!(index.count(), (articles.val.len() as u32).into());
         for i in index.count() {
-            let entry = index.get_entry(&builder, i).unwrap();
+            let entry = index.get_entry(&builder, i).unwrap().expect("Entry i is in the index");
             assert_eq!(entry.get_variant_id().unwrap(), None);
             let value_0 = entry.get_value("V0").unwrap().unwrap();
             let vec = value_0.as_vec().unwrap();

--- a/tests/jubako.rs
+++ b/tests/jubako.rs
@@ -657,10 +657,10 @@ test_suite! {
         for i in index.count() {
             let entry = index.get_entry(&builder, i).unwrap();
             assert_eq!(entry.get_variant_id().unwrap(), None);
-            let value_0 = entry.get_value("V0").unwrap();
+            let value_0 = entry.get_value("V0").unwrap().unwrap();
             let vec = value_0.as_vec().unwrap();
             assert_eq!(vec, articles.val[i.into_u32() as usize].path.as_bytes());
-            let value_1 = entry.get_value("V1").unwrap();
+            let value_1 = entry.get_value("V1").unwrap().unwrap();
             if let reader::RawValue::Content(content) = value_1 {
                 assert_eq!(
                     content,
@@ -674,7 +674,7 @@ test_suite! {
             } else {
               panic!();
             }
-            let value_2= entry.get_value("V2").unwrap();
+            let value_2= entry.get_value("V2").unwrap().unwrap();
             if let reader::RawValue::U16(v) = value_2 {
                 assert_eq!(v, articles.val[i.into_u32() as usize].word_count);
             } else {

--- a/tests/jubako.rs
+++ b/tests/jubako.rs
@@ -667,7 +667,7 @@ test_suite! {
                     jubako::ContentAddress{pack_id:1.into(), content_id:jubako::ContentIdx::from(i.into_u32())}
                 );
                 let bytes = container.get_bytes(content).unwrap();
-                let mut stream = bytes.as_ref().unwrap().stream();
+                let mut stream = bytes.expect("V1 has a valid pack_id").unwrap().expect("V1 has a valid content_id").stream();
                 let mut read_content: String = "".to_string();
                 stream.read_to_string(&mut read_content).unwrap();
                 assert_eq!(read_content, articles.val[i.into_u32() as usize].content);

--- a/tests/jubako.rs
+++ b/tests/jubako.rs
@@ -667,7 +667,7 @@ test_suite! {
                     jubako::ContentAddress{pack_id:1.into(), content_id:jubako::ContentIdx::from(i.into_u32())}
                 );
                 let bytes = container.get_bytes(content).unwrap();
-                let mut stream = bytes.expect("V1 has a valid pack_id").unwrap().expect("V1 has a valid content_id").stream();
+                let mut stream = bytes.and_then(|m| m.transpose()).expect("V1 should be valid").unwrap().stream();
                 let mut read_content: String = "".to_string();
                 stream.read_to_string(&mut read_content).unwrap();
                 assert_eq!(read_content, articles.val[i.into_u32() as usize].content);


### PR DESCRIPTION
This PR tries to get out of the "One big enum error kind".

This introduce a 2 error levels:
- Io error: standard `std::io::Error` but now low level function return it instead of Jubako error
- Jubako error: Mostly as before but with specific variant and without any `dyn Error` or `String`.

`Arg` and `NotFound` error had been removed in favor of methods return an `Result<Option<T>>` instead of `Result<T>`.

This make the api a bit more complex as user have to handle an option but:
- Handling an option is more explicit than handling a Variant of a big enum
- Jubako Error are reserved to jubako error : IoError, invalid files ...

If user pass a wrong argument, it is not a jubako error, it is a user error.
Most library will treat the resulting `Option<T>`, with `.ok_or(CustomError{})?`.
