### PR TITLE
Better definition of VariantName and PropertyName traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ lzma = ["dep:xz2"]
 zstd = ["dep:zstd"]
 explorable = ["dep:graphex", "dep:yansi"]
 clap = ["dep:clap"]
-build_bin = ["explorable", "dep:clap", "dep:const_format", "dep:git-version"]
+build_bin = ["explorable", "dep:clap", "dep:git-version"]
 explorable_serde = ["dep:serde", "dep:erased-serde", "dep:serde_json", "uuid/serde", "graphex/serde"]
 all = ["lz4", "lzma", "zstd", "build_bin", "explorable_serde", "clap"]
 nightly = []
@@ -45,7 +45,7 @@ erased-serde = { version = "0.4", optional = true }
 crc = "3.2.1"
 graphex = { version = "0.2.0", optional = true }
 yansi = { version = "1.0.0", features = ["detect-tty"], optional = true }
-const_format = { version = "0.2.33", optional = true }
+const_format = { version = "0.2.33" }
 git-version = { version = "0.3.9", optional = true }
 thiserror = "2.0.9"
 

--- a/examples/custom_read.rs
+++ b/examples/custom_read.rs
@@ -61,16 +61,30 @@ fn create_builder(
     let layout = store.layout();
     let variants = layout.variant_part.as_ref().unwrap();
     assert_eq!(layout.variant_len(), 2);
-    let value0 = layout.common["AString"]
+    let value0 = layout
+        .common
+        .get("AString")
+        .expect("ASring is in layout")
         .as_builder(value_storage)?
         .expect("Layout proprety should match ArrayProperty");
-    let value1 = layout.common["AInteger"]
+    let value1 = layout
+        .common
+        .get("AInteger")
+        .expect("AInteger is in layout")
         .as_builder(value_storage)?
         .expect("Layout proprety should match IntProperty");
-    let variant0_value2 = variants.get("FirstVariant").unwrap()["TheContent"]
+    let variant0_value2 = variants
+        .get("FirstVariant")
+        .expect("FirstVariant is in layout")
+        .get("TheContent")
+        .expect("TheContent is in layout")
         .as_builder(value_storage)?
         .expect("Layout proprety should match ContentProperty");
-    let variant1_value2 = variants.get("SecondVariant").unwrap()["AnotherInt"]
+    let variant1_value2 = variants
+        .get("SecondVariant")
+        .expect("SecondVariant is in layout")
+        .get("AnotherInt")
+        .expect("AnotherInt is in layout")
         .as_builder(value_storage)?
         .expect("Layout proprety should match IntProperty");
     let variant_id = layout.variant_id_builder().unwrap();

--- a/src/bases/mod.rs
+++ b/src/bases/mod.rs
@@ -88,3 +88,22 @@ where
     nb_bytes = cmp::max(nb_bytes, 1);
     nb_bytes.try_into().unwrap()
 }
+
+pub trait PropertyName: std::cmp::Eq + std::hash::Hash + Copy + Send + 'static {
+    fn as_str(&self) -> &'static str;
+}
+
+impl PropertyName for &'static str {
+    fn as_str(&self) -> &'static str {
+        self
+    }
+}
+
+pub trait VariantName: std::cmp::Eq + std::hash::Hash + Copy + Send {
+    fn as_str(&self) -> &'static str;
+}
+impl VariantName for &'static str {
+    fn as_str(&self) -> &'static str {
+        self
+    }
+}

--- a/src/creator/directory_pack/layout/properties.rs
+++ b/src/creator/directory_pack/layout/properties.rs
@@ -130,7 +130,7 @@ impl<PN: PropertyName + 'static> Properties<PN> {
                         _ => {
                             return Err(Error::wrong_type(format!(
                                 "Value type for {} is not compatible with Array",
-                                name.to_string()
+                                name.as_str()
                             )));
                         }
                     }
@@ -146,7 +146,7 @@ impl<PN: PropertyName + 'static> Properties<PN> {
                     _ => {
                         return Err(Error::wrong_type(format!(
                             "Value type for {} is not compatible with indirect array",
-                            name.to_string()
+                            name.as_str()
                         )));
                     }
                 },
@@ -168,7 +168,7 @@ impl<PN: PropertyName + 'static> Properties<PN> {
                     _ => {
                         return Err(Error::wrong_type(format!(
                             "Value type for {} is not compatible with content",
-                            name.to_string()
+                            name.as_str()
                         )));
                     }
                 },
@@ -194,7 +194,7 @@ impl<PN: PropertyName + 'static> Properties<PN> {
                     _ => {
                         return Err(Error::wrong_type(format!(
                             "Value type for {} is not compatible with unsigned integer",
-                            name.to_string()
+                            name.as_str()
                         )));
                     }
                 },
@@ -220,7 +220,7 @@ impl<PN: PropertyName + 'static> Properties<PN> {
                     _ => {
                         return Err(Error::wrong_type(format!(
                             "Value type for {} is not compatible with signed integer",
-                            name.to_string()
+                            name.as_str()
                         )));
                     }
                 },

--- a/src/creator/directory_pack/layout/property.rs
+++ b/src/creator/directory_pack/layout/property.rs
@@ -4,7 +4,7 @@ use crate::bases::Serializable;
 use crate::bases::*;
 
 pub(crate) enum Property<PN: PropertyName> {
-    VariantId(String),
+    VariantId(&'static str),
     Array {
         array_len_size: Option<ByteSize>,
         fixed_array_len: u8,
@@ -41,7 +41,7 @@ impl<PN: PropertyName> std::fmt::Debug for Property<PN> {
         match self {
             VariantId(name) => f
                 .debug_struct("VariantId")
-                .field("name", &name)
+                .field("name", name)
                 .field("size", &self.size())
                 .finish(),
             Array {
@@ -55,7 +55,7 @@ impl<PN: PropertyName> std::fmt::Debug for Property<PN> {
                 .field("fixed_array_len", &fixed_array_len)
                 .field("deported_info", &deported_info)
                 .field("size", &self.size())
-                .field("name", &name.to_string())
+                .field("name", &name.as_str())
                 .finish(),
             IndirectArray {
                 value_id_size,
@@ -65,7 +65,7 @@ impl<PN: PropertyName> std::fmt::Debug for Property<PN> {
                 .debug_struct("IndirectArray")
                 .field("value_id_size", &value_id_size)
                 .field("store_handle", &store_handle)
-                .field("name", &name.to_string())
+                .field("name", &name.as_str())
                 .finish(),
             ContentAddress {
                 content_id_size,
@@ -78,7 +78,7 @@ impl<PN: PropertyName> std::fmt::Debug for Property<PN> {
                 .field("pack_id_size", &pack_id_size)
                 .field("default", &default)
                 .field("size", &self.size())
-                .field("name", &name.to_string())
+                .field("name", &name.as_str())
                 .finish(),
             UnsignedInt {
                 size,
@@ -89,7 +89,7 @@ impl<PN: PropertyName> std::fmt::Debug for Property<PN> {
                 .field("size", &size)
                 .field("default", &default)
                 .field("size", &self.size())
-                .field("name", &name.to_string())
+                .field("name", &name.as_str())
                 .finish(),
             SignedInt {
                 size,
@@ -100,7 +100,7 @@ impl<PN: PropertyName> std::fmt::Debug for Property<PN> {
                 .field("size", &size)
                 .field("default", &default)
                 .field("size", &self.size())
-                .field("name", &name.to_string())
+                .field("name", &name.as_str())
                 .finish(),
             Padding(_size) => f
                 .debug_struct("Padding")
@@ -202,7 +202,7 @@ impl<PN: PropertyName> Serializable for Property<PN> {
                 if let Some((_, store)) = deported_info {
                     written += store.get_idx().unwrap().serialize(ser)?;
                 }
-                written += PString::serialize_string(name.to_string().as_bytes(), ser)?;
+                written += PString::serialize_string(name.as_str().as_bytes(), ser)?;
                 Ok(written)
             }
             Property::IndirectArray {
@@ -213,7 +213,7 @@ impl<PN: PropertyName> Serializable for Property<PN> {
                 let mut written = ser.write_u8(PropType::Array as u8)?;
                 written += ser.write_u8((*value_id_size as usize as u8) << 5)?;
                 written += store_handle.get_idx().unwrap().serialize(ser)?;
-                written += PString::serialize_string(name.to_string().as_bytes(), ser)?;
+                written += PString::serialize_string(name.as_str().as_bytes(), ser)?;
                 Ok(written)
             }
             Property::ContentAddress {
@@ -236,7 +236,7 @@ impl<PN: PropertyName> Serializable for Property<PN> {
                         written
                     }
                 };
-                written += PString::serialize_string(name.to_string().as_bytes(), ser)?;
+                written += PString::serialize_string(name.as_str().as_bytes(), ser)?;
                 Ok(written)
             }
             Property::UnsignedInt {
@@ -255,7 +255,7 @@ impl<PN: PropertyName> Serializable for Property<PN> {
                         written
                     }
                 };
-                written += PString::serialize_string(name.to_string().as_bytes(), ser)?;
+                written += PString::serialize_string(name.as_str().as_bytes(), ser)?;
                 Ok(written)
             }
             Property::SignedInt {
@@ -274,7 +274,7 @@ impl<PN: PropertyName> Serializable for Property<PN> {
                         written
                     }
                 };
-                written += PString::serialize_string(name.to_string().as_bytes(), ser)?;
+                written += PString::serialize_string(name.as_str().as_bytes(), ser)?;
                 Ok(written)
             }
             Property::Padding(size) => {

--- a/src/creator/directory_pack/mod.rs
+++ b/src/creator/directory_pack/mod.rs
@@ -17,12 +17,6 @@ pub use value::{Array, ArrayS, Value};
 pub(crate) use value_store::ValueStoreKind;
 pub use value_store::{StoreHandle, ValueHandle, ValueStore};
 
-pub trait PropertyName: ToString + std::cmp::Eq + std::hash::Hash + Copy + Send + 'static {}
-impl PropertyName for &'static str {}
-
-pub trait VariantName: ToString + std::cmp::Eq + std::hash::Hash + Copy + Send {}
-impl VariantName for &str {}
-
 pub trait EntryTrait<PN: PropertyName, VN: VariantName> {
     fn variant_name(&self) -> Option<MayRef<VN>>;
     fn value<'a>(&'a self, name: &PN) -> MayRef<'a, Value>;
@@ -89,7 +83,7 @@ impl<'a, PN: PropertyName> ValueTransformer<'a, PN> {
             //[TODO] Transform this as Result
             panic!(
                 "Entry variant name {} doesn't correspond to possible variants",
-                variant_name.unwrap().to_string()
+                variant_name.unwrap().as_str()
             );
         };
     }
@@ -111,7 +105,7 @@ impl<'a, PN: PropertyName> Iterator for ValueTransformer<'a, PN> {
                         let value = self
                             .values
                             .remove(name)
-                            .unwrap_or_else(|| panic!("Cannot find entry {:?}", name.to_string()));
+                            .unwrap_or_else(|| panic!("Cannot find entry {}", name.as_str()));
                         if let common::Value::Array(mut data) = value {
                             let size = data.len();
                             let to_store = data.split_off(cmp::min(*fixed_array_len, data.len()));
@@ -149,7 +143,7 @@ impl<'a, PN: PropertyName> Iterator for ValueTransformer<'a, PN> {
                         let value = self
                             .values
                             .remove(name)
-                            .unwrap_or_else(|| panic!("Cannot find entry {:?}", name.to_string()));
+                            .unwrap_or_else(|| panic!("Cannot find entry {}", name.as_str()));
                         if let common::Value::Array(data) = value {
                             let value_id = store_handle.add_value(data);
                             return Some((*name, Value::IndirectArray(Box::new(value_id))));
@@ -250,7 +244,7 @@ impl<PN: PropertyName, VN: VariantName> EntryTrait<PN, VN> for BasicEntry<PN, VN
     fn value(&self, name: &PN) -> MayRef<Value> {
         match self.names.iter().position(|n| n == name) {
             Some(i) => MayRef::Borrowed(&self.values[i]),
-            None => panic!("{} should be in entry", name.to_string()),
+            None => panic!("{} should be in entry", name.as_str()),
         }
     }
     fn value_count(&self) -> PropertyCount {

--- a/src/creator/directory_pack/schema/mod.rs
+++ b/src/creator/directory_pack/schema/mod.rs
@@ -48,7 +48,7 @@ impl<PN: PropertyName, VN: VariantName> Schema<PN, VN> {
         let mut variants_layout = Vec::new();
         let mut variants_map = HashMap::new();
         for (name, variant) in self.variants {
-            variants_layout.push(variant.finalize(Some(name.to_string())));
+            variants_layout.push(variant.finalize(Some(name.as_str())));
             variants_map.insert(name, (variants_layout.len() as u8 - 1).into());
         }
         let entry_size = if variants_layout.is_empty() {

--- a/src/creator/directory_pack/schema/properties.rs
+++ b/src/creator/directory_pack/schema/properties.rs
@@ -40,7 +40,7 @@ impl<PN: PropertyName> Properties<PN> {
         Self(keys)
     }
 
-    pub(crate) fn finalize(self, variant_name: Option<String>) -> layout::Properties<PN> {
+    pub(crate) fn finalize(self, variant_name: Option<&'static str>) -> layout::Properties<PN> {
         let variant = variant_name.map(layout::Property::VariantId);
         variant
             .into_iter()

--- a/src/creator/directory_pack/schema/property.rs
+++ b/src/creator/directory_pack/schema/property.rs
@@ -129,7 +129,7 @@ impl<PN: PropertyName> std::fmt::Debug for Property<PN> {
                 .debug_struct("UnsignedInt")
                 .field("counter", &counter)
                 .field("size", &size)
-                .field("name", &name.to_string())
+                .field("name", &name.as_str())
                 .finish(),
             Self::SignedInt {
                 counter,
@@ -139,7 +139,7 @@ impl<PN: PropertyName> std::fmt::Debug for Property<PN> {
                 .debug_struct("SignedInt")
                 .field("counter", &counter)
                 .field("size", &size)
-                .field("name", &name.to_string())
+                .field("name", &name.as_str())
                 .finish(),
             Self::Array {
                 max_array_size,
@@ -152,13 +152,13 @@ impl<PN: PropertyName> std::fmt::Debug for Property<PN> {
                 .field("fixed_array_len", &fixed_array_len)
                 .field("store_idx", &store_handle.get_idx())
                 .field("key_size", &store_handle.key_size())
-                .field("name", &name.to_string())
+                .field("name", &name.as_str())
                 .finish(),
             Self::IndirectArray { store_handle, name } => f
                 .debug_struct("IndirectArray")
                 .field("store_idx", &store_handle.get_idx())
                 .field("key_size", &store_handle.key_size())
-                .field("name", &name.to_string())
+                .field("name", &name.as_str())
                 .finish(),
             Self::ContentAddress {
                 pack_id_counter,
@@ -170,7 +170,7 @@ impl<PN: PropertyName> std::fmt::Debug for Property<PN> {
                 .field("pack_id_counter", &pack_id_counter)
                 .field("pack_id_size", &pack_id_size)
                 .field("content_id_size", &content_id_size)
-                .field("name", &name.to_string())
+                .field("name", &name.as_str())
                 .finish(),
             Self::Padding(s) => f.debug_tuple("Padding").field(&s).finish(),
         }

--- a/src/creator/mod.rs
+++ b/src/creator/mod.rs
@@ -17,7 +17,7 @@ pub use content_pack::{
 };
 pub use directory_pack::{
     schema, Array, ArrayS, BasicEntry, DirectoryPackCreator, EntryStore, EntryTrait,
-    FullEntryTrait, PropertyName, StoreHandle, Value, ValueHandle, ValueStore, VariantName,
+    FullEntryTrait, StoreHandle, Value, ValueHandle, ValueStore,
 };
 pub use errors::{Error, Result};
 pub use manifest_pack::ManifestPackCreator;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,9 @@ pub mod tools;
 #[cfg(feature = "clap")]
 pub mod cmd_utils;
 
+#[doc(hidden)]
+pub use const_format::concatcp;
+
 pub use crate::bases::{
     Bound, ContentIdx, EntryCount, EntryIdx, EntryRange, Error, ErrorKind, FileSource, MayRef,
     Offset, PackId, PropertyCount, PropertyIdx, PropertyName, Reader, Result, Size, VariantIdx,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,8 @@ pub mod cmd_utils;
 
 pub use crate::bases::{
     Bound, ContentIdx, EntryCount, EntryIdx, EntryRange, Error, ErrorKind, FileSource, MayRef,
-    Offset, PackId, PropertyCount, PropertyIdx, Reader, Result, Size, VariantIdx, VendorId, Vow,
+    Offset, PackId, PropertyCount, PropertyIdx, PropertyName, Reader, Result, Size, VariantIdx,
+    VariantName, VendorId, Vow,
 };
 pub use crate::common::{CompressionType, ContentAddress, Pack, Value};
 //use crate::reader::directory_pack::layout;

--- a/src/reader/directory_pack/builder/property.rs
+++ b/src/reader/directory_pack/builder/property.rs
@@ -67,6 +67,30 @@ impl PropertyBuilderTrait for VariantIdProperty {
 }
 
 #[derive(Debug, Clone)]
+pub struct VariantIdBuilder<T: Copy> {
+    raw_variant_id_builder: VariantIdProperty,
+    variant_map: Vec<Option<T>>,
+}
+
+impl<T: Copy> VariantIdBuilder<T> {
+    pub fn new(raw_variant_id_builder: VariantIdProperty, variant_map: Vec<Option<T>>) -> Self {
+        Self {
+            raw_variant_id_builder,
+            variant_map,
+        }
+    }
+}
+
+impl<T: Copy> PropertyBuilderTrait for VariantIdBuilder<T> {
+    type Output = Option<T>;
+
+    fn create(&self, parser: &impl RandomParser) -> Result<Self::Output> {
+        let raw_id = self.raw_variant_id_builder.create(parser)?;
+        Ok(self.variant_map[raw_id.into_usize()])
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct IntProperty {
     offset: Offset,
     size: ByteSize,

--- a/src/reader/directory_pack/entry_store.rs
+++ b/src/reader/directory_pack/entry_store.rs
@@ -426,7 +426,7 @@ mod tests {
                 ),
             ),
         ]);
-        assert_eq!(&*store.layout.common, &expected);
+        assert_eq!(store.layout.common.inner(), &expected);
     }
 
     #[test]
@@ -475,7 +475,7 @@ mod tests {
                 },
             ),
         )]);
-        assert_eq!(&*common, &expected);
+        assert_eq!(common.inner(), &expected);
 
         let VariantPart {
             variant_id_offset,
@@ -527,7 +527,7 @@ mod tests {
                 ),
             ),
         ]);
-        assert_eq!(***variant, expected);
+        assert_eq!(variant.inner(), &expected);
         let variant = &variants[1];
         let expected = HashMap::from([
             (
@@ -564,6 +564,6 @@ mod tests {
                 ),
             ),
         ]);
-        assert_eq!(***variant, expected);
+        assert_eq!(variant.inner(), &expected);
     }
 }

--- a/src/reader/directory_pack/layout/properties.rs
+++ b/src/reader/directory_pack/layout/properties.rs
@@ -1,5 +1,6 @@
 use super::super::raw_layout::{PropertyKind, RawProperty};
 use super::property::Property;
+use crate::PropertyName;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -8,13 +9,6 @@ use std::sync::Arc;
 pub struct Properties(HashMap<String, Property>);
 
 pub(crate) type SharedProperties = Arc<Properties>;
-
-impl std::ops::Deref for Properties {
-    type Target = HashMap<String, Property>;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
 
 impl Properties {
     pub(crate) fn new(initial_offset: usize, raw_properties: Vec<RawProperty>) -> Self {
@@ -28,6 +22,19 @@ impl Properties {
             }
         }
         Properties(properties)
+    }
+
+    pub fn get(&self, name: impl PropertyName) -> Option<&Property> {
+        self.0.get(name.as_str())
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &Property)> {
+        self.0.iter()
+    }
+
+    #[cfg(test)]
+    pub fn inner(&self) -> &HashMap<String, Property> {
+        &self.0
     }
 }
 


### PR DESCRIPTION
`ToString` is mainly use to "display" a value.
(And clippy complain about that and propose to implement `Display` instead)

We don't want to display it but get a name (as a `[u8]`) to store in the
container.
Let's be clean on this and add `as_bytes` to `VariantName` and `PropertyName` trait.

This PR also fix a compatibility bug (for future evolution of user format) where we were basing variant detection on the id of the variant and don't use the name. To be future proof we need to base ourselves on the name as variants may be declared in a different order.