### PR TITLE
Introduce usage of small_vec crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ yansi = { version = "1.0.0", features = ["detect-tty"], optional = true }
 const_format = { version = "0.2.33" }
 git-version = { version = "0.3.9", optional = true }
 thiserror = "2.0.9"
+smallvec = { version = "1.13.2", features = ["union"] }
 
 [dev-dependencies]
 test-case = "3.2.1"

--- a/examples/custom_read.rs
+++ b/examples/custom_read.rs
@@ -64,7 +64,7 @@ jbk::properties! {
 // while a function printing the content will have to parse the reader variant type and
 // the content reference.
 pub struct Entry {
-    value0: Vec<u8>,
+    value0: jbk::SmallBytes,
     value1: u64,
     variant: Variant,
 }
@@ -152,7 +152,7 @@ impl jbk::reader::builder::BuilderTrait for Builder {
         // Value0 is a array with a part stored in a value store.
         // The property builder only parse the bytes in the entry_store
         // so we have to "resolve" the property to get the data from the value_store.
-        let mut value0 = Vec::new();
+        let mut value0 = jbk::SmallBytes::new();
         self.value0.create(&reader)?.resolve_to_vec(&mut value0)?;
 
         // Read value1

--- a/examples/simple_read.rs
+++ b/examples/simple_read.rs
@@ -20,10 +20,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             .get_entry(&builder, 0.into())?
             .expect("We have the entry 0");
         assert_eq!(entry.get_variant_id().unwrap(), Some(0.into())); // We correctly have variant 0
-        assert_eq!(
-            entry.get_value("AString")?.unwrap().as_vec()?,
-            Vec::from("Super")
-        );
+        assert_eq!(entry.get_value("AString")?.unwrap().as_vec()?, b"Super");
         assert_eq!(entry.get_value("AInteger")?.unwrap().as_unsigned(), 50);
         let value_2 = entry.get_value("TheContent")?.unwrap();
         let content_address = value_2.as_content();
@@ -41,10 +38,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             .get_entry(&builder, 1.into())?
             .expect("We have the entry 1");
         assert_eq!(entry.get_variant_id().unwrap(), Some(1.into()));
-        assert_eq!(
-            entry.get_value("AString")?.unwrap().as_vec()?,
-            Vec::from("Mega")
-        );
+        assert_eq!(entry.get_value("AString")?.unwrap().as_vec()?, b"Mega");
         assert_eq!(entry.get_value("AInteger")?.unwrap().as_unsigned(), 42);
         assert_eq!(entry.get_value("AnotherInt")?.unwrap().as_unsigned(), 5);
     }
@@ -55,10 +49,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             .expect("We have the entry 2");
 
         assert_eq!(entry.get_variant_id().unwrap(), Some(1.into()));
-        assert_eq!(
-            entry.get_value("AString")?.unwrap().as_vec()?,
-            Vec::from("Hyper")
-        );
+        assert_eq!(entry.get_value("AString")?.unwrap().as_vec()?, b"Hyper");
         assert_eq!(entry.get_value("AInteger")?.unwrap().as_unsigned(), 45);
         assert_eq!(entry.get_value("AnotherInt")?.unwrap().as_unsigned(), 2);
     }

--- a/src/bases/types/error.rs
+++ b/src/bases/types/error.rs
@@ -5,7 +5,7 @@ use std::backtrace::Backtrace;
 
 use std::fmt;
 use std::ops::Deref;
-use std::string::FromUtf8Error;
+use std::{str::Utf8Error, string::FromUtf8Error};
 
 use thiserror::Error;
 #[cfg(feature = "lzma")]
@@ -164,6 +164,12 @@ impl_from_error!(CorruptedFile);
 
 impl From<FromUtf8Error> for Error {
     fn from(_e: FromUtf8Error) -> Error {
+        FormatError::new("Utf8DecodingError", None).into()
+    }
+}
+
+impl From<Utf8Error> for Error {
+    fn from(_e: Utf8Error) -> Error {
         FormatError::new("Utf8DecodingError", None).into()
     }
 }

--- a/src/bases/types/mod.rs
+++ b/src/bases/types/mod.rs
@@ -14,6 +14,7 @@ mod pstring;
 mod range;
 mod size;
 mod sized_offset;
+mod small_bytes;
 mod specific_types;
 mod vendor_id;
 
@@ -36,5 +37,6 @@ pub use range::EntryRange;
 pub(crate) use range::{ARegion, Region};
 pub use size::Size;
 pub(crate) use sized_offset::SizedOffset;
+pub use small_bytes::SmallBytes;
 pub use specific_types::*;
 pub use vendor_id::VendorId;

--- a/src/bases/types/mod.rs
+++ b/src/bases/types/mod.rs
@@ -31,7 +31,7 @@ pub(crate) use id::Id;
 pub(crate) use idx::{Idx, IndexTrait};
 pub use mayref::MayRef;
 pub use offset::Offset;
-pub(crate) use pstring::PString;
+pub(crate) use pstring::{PBytes, PString};
 pub use range::EntryRange;
 pub(crate) use range::{ARegion, Region};
 pub use size::Size;

--- a/src/bases/types/mod.rs
+++ b/src/bases/types/mod.rs
@@ -15,6 +15,7 @@ mod range;
 mod size;
 mod sized_offset;
 mod small_bytes;
+mod small_string;
 mod specific_types;
 mod vendor_id;
 
@@ -38,5 +39,6 @@ pub(crate) use range::{ARegion, Region};
 pub use size::Size;
 pub(crate) use sized_offset::SizedOffset;
 pub use small_bytes::SmallBytes;
+pub use small_string::SmallString;
 pub use specific_types::*;
 pub use vendor_id::VendorId;

--- a/src/bases/types/pstring.rs
+++ b/src/bases/types/pstring.rs
@@ -57,11 +57,10 @@ impl Parsable for PArray<SmallBytes> {
 }
 
 impl Parsable for PArray<String> {
-    type Output = String;
-    fn parse(parser: &mut impl Parser) -> Result<String> {
-        let size = parser.read_u8()?;
-        let data = parser.read_slice(size as usize)?;
-        Ok(String::from_utf8(data.into())?)
+    type Output = SmallString;
+    fn parse(parser: &mut impl Parser) -> Result<SmallString> {
+        let data = PArray::<SmallBytes>::parse(parser)?;
+        Ok(SmallString::from_byte_vec(data)?)
     }
 }
 
@@ -84,6 +83,7 @@ mod tests {
         reader
             .parse_in::<PString>(Offset::zero(), reader.size().try_into().unwrap())
             .unwrap()
+            .to_string()
     }
 
     #[test_case(&[0x00] => b"".as_slice())]

--- a/src/bases/types/pstring.rs
+++ b/src/bases/types/pstring.rs
@@ -1,38 +1,67 @@
+use core::{borrow::Borrow, marker::PhantomData};
+
 use crate::bases::*;
 
-pub struct PString {}
+pub struct PArray<Output> {
+    _output: PhantomData<Output>,
+}
 
-impl PString {
-    fn serialize_string_size(string: &[u8], max_len: u8, ser: &mut Serializer) -> IoResult<usize> {
+impl<Output> PArray<Output> {
+    fn serialize_string_size<T>(string: &T, max_len: u8, ser: &mut Serializer) -> IoResult<usize>
+    where
+        Output: Borrow<T>,
+        T: AsRef<[u8]> + ?Sized,
+    {
+        let string = string.as_ref();
         assert!(string.len() <= max_len.into());
         let mut written = 0;
         written += ser.write_u8(string.len() as u8)?;
         written += ser.write_data(string)?;
         Ok(written)
     }
-    pub(crate) fn serialize_string(string: &[u8], ser: &mut Serializer) -> IoResult<usize> {
+    pub(crate) fn serialize_string<T>(string: &T, ser: &mut Serializer) -> IoResult<usize>
+    where
+        Output: Borrow<T>,
+        T: AsRef<[u8]> + ?Sized,
+    {
         Self::serialize_string_size(string, 255, ser)
     }
 
-    pub(crate) fn serialize_string_padded(
-        string: &[u8],
+    pub(crate) fn serialize_string_padded<T>(
+        string: &T,
         size: u8,
         ser: &mut Serializer,
-    ) -> IoResult<usize> {
+    ) -> IoResult<usize>
+    where
+        Output: Borrow<T>,
+        T: AsRef<[u8]> + ?Sized,
+    {
         let mut written = 0;
         written += Self::serialize_string_size(string, size, ser)?;
-        written += ser.write_data(vec![0; size as usize - string.len()].as_slice())?;
+        written += ser.write_data(vec![0; size as usize - string.as_ref().len()].as_slice())?;
         Ok(written)
     }
 }
 
-impl Parsable for PString {
+impl Parsable for PArray<Vec<u8>> {
     type Output = Vec<u8>;
     fn parse(parser: &mut impl Parser) -> Result<Vec<u8>> {
         let size = parser.read_u8()?;
         Ok(parser.read_slice(size as usize)?.into_owned())
     }
 }
+
+impl Parsable for PArray<String> {
+    type Output = String;
+    fn parse(parser: &mut impl Parser) -> Result<String> {
+        let size = parser.read_u8()?;
+        let data = parser.read_slice(size as usize)?;
+        Ok(String::from_utf8(data.into())?)
+    }
+}
+
+pub type PBytes = PArray<Vec<u8>>;
+pub type PString = PArray<String>;
 
 #[cfg(test)]
 mod tests {
@@ -47,11 +76,21 @@ mod tests {
         let mut content = Vec::new();
         content.extend_from_slice(source);
         let reader = CheckReader::from(content);
-        String::from_utf8(
-            reader
-                .parse_in::<PString>(Offset::zero(), reader.size().try_into().unwrap())
-                .unwrap(),
-        )
-        .unwrap()
+        reader
+            .parse_in::<PArray<String>>(Offset::zero(), reader.size().try_into().unwrap())
+            .unwrap()
+    }
+
+    #[test_case(&[0x00] => b"".as_slice())]
+    #[test_case(&[0x01, 72] => b"H".as_slice())]
+    #[test_case(&[0x02, 72, 101] => b"He".as_slice())]
+    #[test_case(&[0x03, 72, 0xC3, 0xA9] => "Hé".as_bytes())]
+    fn test_pvec(source: &[u8]) -> Vec<u8> {
+        let mut content = Vec::new();
+        content.extend_from_slice(source);
+        let reader = CheckReader::from(content);
+        reader
+            .parse_in::<PArray<Vec<u8>>>(Offset::zero(), reader.size().try_into().unwrap())
+            .unwrap()
     }
 }

--- a/src/bases/types/small_bytes.rs
+++ b/src/bases/types/small_bytes.rs
@@ -1,0 +1,90 @@
+use std::{borrow::Borrow, ops::Deref};
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct SmallBytes(smallvec::SmallVec<[u8; 2 * size_of::<usize>()]>);
+
+impl SmallBytes {
+    pub fn new() -> Self {
+        Self(smallvec::SmallVec::new())
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+
+    pub fn reserve(&mut self, additional: usize) {
+        self.0.reserve(additional)
+    }
+
+    pub fn push(&mut self, value: u8) {
+        self.0.push(value)
+    }
+
+    pub fn extend_from_slice(&mut self, slice: &[u8]) {
+        self.0.extend_from_slice(slice);
+    }
+}
+
+impl From<Vec<u8>> for SmallBytes {
+    fn from(value: Vec<u8>) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<&[u8]> for SmallBytes {
+    fn from(value: &[u8]) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<&str> for SmallBytes {
+    fn from(value: &str) -> Self {
+        Self(value.as_bytes().into())
+    }
+}
+
+impl<const N: usize> From<&[u8; N]> for SmallBytes {
+    fn from(value: &[u8; N]) -> Self {
+        Self(value.as_slice().into())
+    }
+}
+
+impl Deref for SmallBytes {
+    type Target = [u8];
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.0.as_slice()
+    }
+}
+
+impl AsRef<[u8]> for SmallBytes {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+}
+
+impl Borrow<[u8]> for SmallBytes {
+    #[inline]
+    fn borrow(&self) -> &[u8] {
+        self
+    }
+}
+
+impl PartialEq<&[u8]> for SmallBytes {
+    fn eq(&self, other: &&[u8]) -> bool {
+        self.0.as_slice() == *other
+    }
+}
+
+impl<const N: usize> PartialEq<&[u8; N]> for SmallBytes {
+    fn eq(&self, other: &&[u8; N]) -> bool {
+        self.0.as_slice() == other.as_slice()
+    }
+}
+
+impl From<SmallBytes> for Box<[u8]> {
+    fn from(value: SmallBytes) -> Self {
+        value.0.into_boxed_slice()
+    }
+}

--- a/src/bases/types/small_string.rs
+++ b/src/bases/types/small_string.rs
@@ -1,0 +1,136 @@
+use std::{borrow::Borrow, fmt::Display, ops::Deref, str::Utf8Error};
+
+use crate::SmallBytes;
+
+/// A SmallVec which is guaranty to be a value utf8 content.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub struct SmallString(SmallBytes);
+
+impl SmallString {
+    pub fn as_str(&self) -> &str {
+        // SAFETY: Bytes in SmallVec is guaranted to be valid utf8 from
+        // SmallString contructors and the absence of way to modify this SmallVec.
+        unsafe { std::str::from_utf8_unchecked(&self.0) }
+    }
+}
+
+impl SmallString {
+    pub fn from_byte_vec(buf: SmallBytes) -> Result<Self, Utf8Error> {
+        match std::str::from_utf8(buf.as_ref()) {
+            Ok(_) => Ok(Self(buf)),
+            Err(e) => Err(e),
+        }
+    }
+
+    pub fn from_byte_slice(buf: &[u8]) -> Result<Self, Utf8Error> {
+        match std::str::from_utf8(buf) {
+            Ok(_) => Ok(Self(buf.into())),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+impl std::hash::Hash for SmallString {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.as_str().hash(state)
+    }
+}
+
+impl From<&str> for SmallString {
+    fn from(value: &str) -> Self {
+        Self(SmallBytes::from(value.as_bytes()))
+    }
+}
+
+impl TryFrom<SmallBytes> for SmallString {
+    type Error = Utf8Error;
+    fn try_from(value: SmallBytes) -> Result<Self, Self::Error> {
+        Self::from_byte_vec(value)
+    }
+}
+
+impl TryFrom<&[u8]> for SmallString {
+    type Error = Utf8Error;
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        Self::from_byte_slice(value)
+    }
+}
+
+impl<const N: usize> TryFrom<&[u8; N]> for SmallString {
+    type Error = Utf8Error;
+    fn try_from(value: &[u8; N]) -> Result<Self, Self::Error> {
+        Self::from_byte_slice(value.as_slice())
+    }
+}
+
+impl Deref for SmallString {
+    type Target = str;
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+impl AsRef<str> for SmallString {
+    #[inline]
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Borrow<str> for SmallString {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Display for SmallString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+#[cfg(feature = "explorable_serde")]
+impl serde::Serialize for SmallString {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::hash::DefaultHasher;
+
+    use super::*;
+    #[test]
+    fn byte_string_ok() {
+        assert_eq!(SmallString::from("Hello").as_ref(), "Hello");
+        assert_eq!(SmallString::from("Héllü").as_ref(), "Héllü");
+        assert_eq!(SmallString::from("Héllü\x57").as_ref(), "HéllüW");
+    }
+
+    #[test]
+    fn byte_string_ko() {
+        assert!(SmallString::try_from(b"Hello\xFF").is_err());
+    }
+
+    #[test]
+    fn hash_equal() {
+        use std::hash::{Hash, Hasher};
+        let b_hash = {
+            let b = SmallString::from("Hello");
+            let mut s = DefaultHasher::new();
+            b.hash(&mut s);
+            s.finish()
+        };
+        let s_hash = {
+            let mut s = DefaultHasher::new();
+            "Hello".hash(&mut s);
+            s.finish()
+        };
+        assert_eq!(b_hash, s_hash);
+    }
+}

--- a/src/common/pack_info.rs
+++ b/src/common/pack_info.rs
@@ -45,7 +45,7 @@ impl Serializable for PackInfo {
         written += self.pack_kind.serialize(ser)?;
         written += ser.write_u8(self.pack_group)?;
         written += ser.write_u16(self.free_data_id.into_u64() as u16)?;
-        written += PString::serialize_string_padded(self.pack_location.as_ref(), 213, ser)?;
+        written += PBytes::serialize_string_padded(&self.pack_location, 213, ser)?;
         Ok(written)
     }
 }
@@ -73,7 +73,7 @@ impl Parsable for PackInfo {
         let pack_kind = PackKind::parse(parser)?;
         let pack_group = parser.read_u8()?;
         let free_data_id = ValueIdx::from(parser.read_u16()? as u64);
-        let pack_location = PString::parse(parser)?;
+        let pack_location = PBytes::parse(parser)?;
         parser.skip(213 - pack_location.len())?;
         Ok(Self {
             uuid,

--- a/src/common/pack_info.rs
+++ b/src/common/pack_info.rs
@@ -45,7 +45,7 @@ impl Serializable for PackInfo {
         written += self.pack_kind.serialize(ser)?;
         written += ser.write_u8(self.pack_group)?;
         written += ser.write_u16(self.free_data_id.into_u64() as u16)?;
-        written += PBytes::serialize_string_padded(&self.pack_location, 213, ser)?;
+        written += PBytes::serialize_string_padded(self.pack_location.as_slice(), 213, ser)?;
         Ok(written)
     }
 }
@@ -73,7 +73,7 @@ impl Parsable for PackInfo {
         let pack_kind = PackKind::parse(parser)?;
         let pack_group = parser.read_u8()?;
         let free_data_id = ValueIdx::from(parser.read_u16()? as u64);
-        let pack_location = PBytes::parse(parser)?;
+        let pack_location = PBytes::parse(parser)?.to_vec();
         parser.skip(213 - pack_location.len())?;
         Ok(Self {
             uuid,

--- a/src/common/value.rs
+++ b/src/common/value.rs
@@ -8,5 +8,5 @@ pub enum Value {
     Signed(i64),
     UnsignedWord(Word<u64>),
     SignedWord(Word<i64>),
-    Array(Vec<u8>),
+    Array(SmallBytes),
 }

--- a/src/creator/directory_pack/layout/property.rs
+++ b/src/creator/directory_pack/layout/property.rs
@@ -178,7 +178,7 @@ impl<PN: PropertyName> Serializable for Property<PN> {
         match self {
             Property::VariantId(name) => {
                 let mut written = ser.write_u8(PropType::VariantId as u8)?;
-                written += PString::serialize_string(name.as_bytes(), ser)?;
+                written += PString::serialize_string(*name, ser)?;
                 Ok(written)
             }
             Property::Array {
@@ -202,7 +202,7 @@ impl<PN: PropertyName> Serializable for Property<PN> {
                 if let Some((_, store)) = deported_info {
                     written += store.get_idx().unwrap().serialize(ser)?;
                 }
-                written += PString::serialize_string(name.as_str().as_bytes(), ser)?;
+                written += PString::serialize_string(name.as_str(), ser)?;
                 Ok(written)
             }
             Property::IndirectArray {
@@ -213,7 +213,7 @@ impl<PN: PropertyName> Serializable for Property<PN> {
                 let mut written = ser.write_u8(PropType::Array as u8)?;
                 written += ser.write_u8((*value_id_size as usize as u8) << 5)?;
                 written += store_handle.get_idx().unwrap().serialize(ser)?;
-                written += PString::serialize_string(name.as_str().as_bytes(), ser)?;
+                written += PString::serialize_string(name.as_str(), ser)?;
                 Ok(written)
             }
             Property::ContentAddress {
@@ -236,7 +236,7 @@ impl<PN: PropertyName> Serializable for Property<PN> {
                         written
                     }
                 };
-                written += PString::serialize_string(name.as_str().as_bytes(), ser)?;
+                written += PString::serialize_string(name.as_str(), ser)?;
                 Ok(written)
             }
             Property::UnsignedInt {
@@ -255,7 +255,7 @@ impl<PN: PropertyName> Serializable for Property<PN> {
                         written
                     }
                 };
-                written += PString::serialize_string(name.as_str().as_bytes(), ser)?;
+                written += PString::serialize_string(name.as_str(), ser)?;
                 Ok(written)
             }
             Property::SignedInt {
@@ -274,7 +274,7 @@ impl<PN: PropertyName> Serializable for Property<PN> {
                         written
                     }
                 };
-                written += PString::serialize_string(name.as_str().as_bytes(), ser)?;
+                written += PString::serialize_string(name.as_str(), ser)?;
                 Ok(written)
             }
             Property::Padding(size) => {

--- a/src/creator/directory_pack/mod.rs
+++ b/src/creator/directory_pack/mod.rs
@@ -333,7 +333,7 @@ impl super::private::WritableTell for Index {
         self.offset.get().serialize(ser)?;
         self.free_data.serialize(ser)?;
         self.index_key.serialize(ser)?;
-        PString::serialize_string(self.name.as_ref(), ser)?;
+        PString::serialize_string(&self.name, ser)?;
         Ok(())
     }
 }

--- a/src/creator/directory_pack/mod.rs
+++ b/src/creator/directory_pack/mod.rs
@@ -106,9 +106,10 @@ impl<'a, PN: PropertyName> Iterator for ValueTransformer<'a, PN> {
                             .values
                             .remove(name)
                             .unwrap_or_else(|| panic!("Cannot find entry {}", name.as_str()));
-                        if let common::Value::Array(mut data) = value {
+                        if let common::Value::Array(data) = value {
                             let size = data.len();
-                            let to_store = data.split_off(cmp::min(*fixed_array_len, data.len()));
+                            let (data, to_store) =
+                                data.split_at(cmp::min(*fixed_array_len, data.len()));
                             let value_id = store_handle.add_value(to_store);
                             return Some((
                                 *name,
@@ -121,7 +122,7 @@ impl<'a, PN: PropertyName> Iterator for ValueTransformer<'a, PN> {
                                     1 => Value::Array1(Box::new(ArrayS::<1> {
                                         size,
                                         value_id,
-                                        data: data.as_slice().try_into().unwrap(),
+                                        data: data.try_into().unwrap(),
                                     })),
                                     2 => Value::Array2(Box::new(ArrayS::<2> {
                                         size,
@@ -130,7 +131,7 @@ impl<'a, PN: PropertyName> Iterator for ValueTransformer<'a, PN> {
                                     })),
                                     _ => Value::Array(Box::new(Array {
                                         size,
-                                        data: data.into_boxed_slice(),
+                                        data: data.into(),
                                         value_id,
                                     })),
                                 },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ pub use const_format::concatcp;
 pub use crate::bases::{
     Bound, ContentIdx, EntryCount, EntryIdx, EntryRange, Error, ErrorKind, FileSource, MayRef,
     Offset, PackId, PropertyCount, PropertyIdx, PropertyName, Reader, Result, Size, SmallBytes,
-    VariantIdx, VariantName, VendorId, Vow,
+    SmallString, VariantIdx, VariantName, VendorId, Vow,
 };
 pub use crate::common::{CompressionType, ContentAddress, Pack, Value};
 //use crate::reader::directory_pack::layout;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,8 @@ pub use const_format::concatcp;
 
 pub use crate::bases::{
     Bound, ContentIdx, EntryCount, EntryIdx, EntryRange, Error, ErrorKind, FileSource, MayRef,
-    Offset, PackId, PropertyCount, PropertyIdx, PropertyName, Reader, Result, Size, VariantIdx,
-    VariantName, VendorId, Vow,
+    Offset, PackId, PropertyCount, PropertyIdx, PropertyName, Reader, Result, Size, SmallBytes,
+    VariantIdx, VariantName, VendorId, Vow,
 };
 pub use crate::common::{CompressionType, ContentAddress, Pack, Value};
 //use crate::reader::directory_pack::layout;

--- a/src/reader/directory_pack/builder/mod.rs
+++ b/src/reader/directory_pack/builder/mod.rs
@@ -24,7 +24,7 @@ pub trait BuilderTrait {
 }
 
 pub struct AnyVariantBuilder {
-    properties: HashMap<String, AnyProperty>,
+    properties: HashMap<SmallString, AnyProperty>,
 }
 
 impl AnyVariantBuilder {
@@ -49,7 +49,7 @@ impl AnyVariantBuilder {
     where
         ValueStorage: ValueStorageTrait,
     {
-        let properties: Result<HashMap<String, _>> = properties
+        let properties: Result<HashMap<SmallString, _>> = properties
             .iter()
             .map(|(n, p)| {
                 AnyProperty::from_property(p, value_storage).map(|p| {
@@ -71,7 +71,7 @@ pub(crate) struct LazyEntryProperties {
     pub variant_part: Option<(
         VariantIdProperty,
         Vec<AnyVariantBuilder>,
-        HashMap<String, u8>,
+        HashMap<SmallString, u8>,
     )>,
 }
 
@@ -187,7 +187,7 @@ mod tests {
                             default_pack_id: None,
                         },
                         4,
-                        Some("V0".to_string()),
+                        "V0",
                     ),
                     RawProperty::new(
                         PropertyKind::UnsignedInt {
@@ -195,7 +195,7 @@ mod tests {
                             default: None,
                         },
                         2,
-                        Some("V11".to_string()),
+                        "V11",
                     ),
                 ],
             ),
@@ -262,7 +262,7 @@ mod tests {
                                     default: None,
                                 },
                                 5,
-                                Some("V0".to_string()),
+                                "V0",
                             ),
                             RawProperty::new(
                                 PropertyKind::UnsignedInt {
@@ -270,7 +270,7 @@ mod tests {
                                     default: None,
                                 },
                                 2,
-                                Some("V1".to_string()),
+                                "V1",
                             ),
                         ],
                     )
@@ -286,16 +286,16 @@ mod tests {
                                     default: None,
                                 },
                                 2,
-                                Some("V0".to_string()),
+                                "V0",
                             ),
-                            RawProperty::new(PropertyKind::Padding, 2, Some("V1".to_string())),
+                            RawProperty::new(PropertyKind::Padding, 2, "V1"),
                             RawProperty::new(
                                 PropertyKind::SignedInt {
                                     int_size: ByteSize::U1,
                                     default: None,
                                 },
                                 1,
-                                Some("V2".to_string()),
+                                "V2",
                             ),
                             RawProperty::new(
                                 PropertyKind::UnsignedInt {
@@ -303,16 +303,13 @@ mod tests {
                                     default: None,
                                 },
                                 2,
-                                Some("V3".to_string()),
+                                "V3",
                             ),
                         ],
                     )
                     .into(),
                 ]),
-                names: HashMap::from([
-                    (String::from("Variant1"), 0),
-                    (String::from("Variant2"), 1),
-                ]),
+                names: HashMap::from([("Variant1".into(), 0), ("Variant2".into(), 1)]),
             }),
             entry_count: EntryCount::from(2),
             is_entry_checked: false,

--- a/src/reader/directory_pack/builder/property.rs
+++ b/src/reader/directory_pack/builder/property.rs
@@ -69,14 +69,14 @@ impl PropertyBuilderTrait for VariantIdProperty {
 #[derive(Debug, Clone)]
 pub struct VariantIdBuilder<T: Copy> {
     raw_variant_id_builder: VariantIdProperty,
-    variant_map: Vec<Option<T>>,
+    variant_map: smallvec::SmallVec<[Option<T>; 4]>,
 }
 
 impl<T: Copy> VariantIdBuilder<T> {
     pub fn new(raw_variant_id_builder: VariantIdProperty, variant_map: Vec<Option<T>>) -> Self {
         Self {
             raw_variant_id_builder,
-            variant_map,
+            variant_map: variant_map.into(),
         }
     }
 }

--- a/src/reader/directory_pack/entry_store.rs
+++ b/src/reader/directory_pack/entry_store.rs
@@ -248,7 +248,7 @@ mod tests {
         assert!(store.layout.variant_part.is_none());
         let expected = HashMap::from([
             (
-                "V0".to_string(),
+                "V0".into(),
                 Property::new(
                     8,
                     PropertyKind::ContentAddress {
@@ -259,7 +259,7 @@ mod tests {
                 ),
             ),
             (
-                "V1".to_string(),
+                "V1".into(),
                 Property::new(
                     12,
                     PropertyKind::UnsignedInt {
@@ -269,7 +269,7 @@ mod tests {
                 ),
             ),
             (
-                "V2".to_string(),
+                "V2".into(),
                 Property::new(
                     13,
                     PropertyKind::UnsignedInt {
@@ -279,7 +279,7 @@ mod tests {
                 ),
             ),
             (
-                "V3".to_string(),
+                "V3".into(),
                 Property::new(
                     16,
                     PropertyKind::UnsignedInt {
@@ -289,7 +289,7 @@ mod tests {
                 ),
             ),
             (
-                "V4".to_string(),
+                "V4".into(),
                 Property::new(
                     24,
                     PropertyKind::SignedInt {
@@ -299,7 +299,7 @@ mod tests {
                 ),
             ),
             (
-                "V5".to_string(),
+                "V5".into(),
                 Property::new(
                     25,
                     PropertyKind::SignedInt {
@@ -309,7 +309,7 @@ mod tests {
                 ),
             ),
             (
-                "V6".to_string(),
+                "V6".into(),
                 Property::new(
                     28,
                     PropertyKind::SignedInt {
@@ -319,7 +319,7 @@ mod tests {
                 ),
             ),
             (
-                "V7".to_string(),
+                "V7".into(),
                 Property::new(
                     36,
                     PropertyKind::Array {
@@ -331,7 +331,7 @@ mod tests {
                 ),
             ),
             (
-                "V8".to_string(),
+                "V8".into(),
                 Property::new(
                     39,
                     PropertyKind::Array {
@@ -343,7 +343,7 @@ mod tests {
                 ),
             ),
             (
-                "V9".to_string(),
+                "V9".into(),
                 Property::new(
                     49,
                     PropertyKind::Array {
@@ -355,7 +355,7 @@ mod tests {
                 ),
             ),
             (
-                "V10".to_string(),
+                "V10".into(),
                 Property::new(
                     82,
                     PropertyKind::Array {
@@ -370,7 +370,7 @@ mod tests {
                 ),
             ),
             (
-                "V11".to_string(),
+                "V11".into(),
                 Property::new(
                     84,
                     PropertyKind::Array {
@@ -385,7 +385,7 @@ mod tests {
                 ),
             ),
             (
-                "V12".to_string(),
+                "V12".into(),
                 Property::new(
                     93,
                     PropertyKind::Array {
@@ -400,7 +400,7 @@ mod tests {
                 ),
             ),
             (
-                "V13".to_string(),
+                "V13".into(),
                 Property::new(
                     97,
                     PropertyKind::Array {
@@ -415,7 +415,7 @@ mod tests {
                 ),
             ),
             (
-                "V14".to_string(),
+                "V14".into(),
                 Property::new(
                     108,
                     PropertyKind::ContentAddress {
@@ -461,7 +461,7 @@ mod tests {
         let EntryStore::Plain(store) = store;
         let common = store.layout.common;
         let expected = HashMap::from([(
-            "C0".to_string(),
+            "C0".into(),
             Property::new(
                 7,
                 PropertyKind::Array {
@@ -484,14 +484,11 @@ mod tests {
         } = store.layout.variant_part.unwrap();
         assert_eq!(variant_id_offset, Offset::new(12));
         assert_eq!(variants.len(), 2);
-        assert_eq!(
-            names,
-            HashMap::from([(String::from("VA0"), 0), (String::from("VA1"), 1)])
-        );
+        assert_eq!(names, HashMap::from([("VA0".into(), 0), ("VA1".into(), 1)]));
         let variant = &variants[0];
         let expected = HashMap::from([
             (
-                "V0".to_string(),
+                "V0".into(),
                 Property::new(
                     13,
                     PropertyKind::Array {
@@ -506,7 +503,7 @@ mod tests {
                 ),
             ),
             (
-                "V1".to_string(),
+                "V1".into(),
                 Property::new(
                     22,
                     PropertyKind::ContentAddress {
@@ -517,7 +514,7 @@ mod tests {
                 ),
             ),
             (
-                "V2".to_string(),
+                "V2".into(),
                 Property::new(
                     26,
                     PropertyKind::UnsignedInt {
@@ -531,7 +528,7 @@ mod tests {
         let variant = &variants[1];
         let expected = HashMap::from([
             (
-                "V0".to_string(),
+                "V0".into(),
                 Property::new(
                     13,
                     PropertyKind::Array {
@@ -543,7 +540,7 @@ mod tests {
                 ),
             ),
             (
-                "V1".to_string(),
+                "V1".into(),
                 Property::new(
                     21,
                     PropertyKind::ContentAddress {
@@ -554,7 +551,7 @@ mod tests {
                 ),
             ),
             (
-                "V2".to_string(),
+                "V2".into(),
                 Property::new(
                     25,
                     PropertyKind::UnsignedInt {

--- a/src/reader/directory_pack/index.rs
+++ b/src/reader/directory_pack/index.rs
@@ -14,7 +14,7 @@ pub(crate) struct IndexHeader {
     pub entry_offset: EntryIdx,
     pub free_data: IndexFreeData,
     pub index_property: u8,
-    pub name: String,
+    pub name: SmallString,
 }
 
 #[cfg(feature = "explorable")]
@@ -23,7 +23,7 @@ impl graphex::Display for IndexHeader {
         Some(("Index(".to_string(), ")".to_string()))
     }
     fn print_content(&self, out: &mut graphex::Output) -> graphex::Result {
-        out.field("name", &self.name)?;
+        out.field("name", &self.name.as_str())?;
         out.field("store_id", &self.store_id.into_u64())?;
         out.field("entry_count", &self.entry_count.into_u64())?;
         out.field("entry_offset", &self.entry_offset.into_u64())?;
@@ -142,7 +142,7 @@ mod tests {
                 entry_offset: EntryIdx::from(2),
                 free_data: [0x00; 4].into(),
                 index_property: 1,
-                name: String::from("Hello")
+                name: "Hello".into()
             }
         );
     }

--- a/src/reader/directory_pack/index.rs
+++ b/src/reader/directory_pack/index.rs
@@ -40,7 +40,7 @@ impl Parsable for IndexHeader {
         let entry_offset = Idx::<u32>::parse(parser)?.into();
         let free_data = IndexFreeData::parse(parser)?;
         let index_property = parser.read_u8()?;
-        let name = String::from_utf8(PString::parse(parser)?)?;
+        let name = PString::parse(parser)?;
         Ok(Self {
             store_id,
             entry_count,

--- a/src/reader/directory_pack/layout/mod.rs
+++ b/src/reader/directory_pack/layout/mod.rs
@@ -21,7 +21,7 @@ use std::cmp::Ordering;
 pub struct VariantPart {
     pub variant_id_offset: Offset,
     pub variants: Box<[SharedProperties]>,
-    pub names: HashMap<String, u8>,
+    pub names: HashMap<SmallString, u8>,
 }
 
 impl VariantPart {
@@ -134,7 +134,7 @@ impl Parsable for Layout {
             let mut variants = Vec::new();
             let mut variants_map = HashMap::new();
             let mut variant_def = Vec::new();
-            let mut variant_name: Option<String> = None;
+            let mut variant_name: Option<SmallString> = None;
             for raw_property in property_iter {
                 if !raw_property.is_variant_id() && variant_name.is_none() {
                     return Err(format_error!(
@@ -150,7 +150,7 @@ impl Parsable for Layout {
                 }
                 if raw_property.is_variant_id() {
                     // This is a special property
-                    variant_name = raw_property.name;
+                    variant_name = Some(raw_property.name);
                     continue;
                 }
                 variant_size += raw_property.size;

--- a/src/reader/directory_pack/layout/properties.rs
+++ b/src/reader/directory_pack/layout/properties.rs
@@ -1,12 +1,13 @@
 use super::super::raw_layout::{PropertyKind, RawProperty};
 use super::property::Property;
+use super::SmallString;
 use crate::PropertyName;
 use std::collections::HashMap;
 use std::sync::Arc;
 
 #[derive(Debug)]
 #[cfg_attr(feature = "explorable_serde", derive(serde::Serialize))]
-pub struct Properties(HashMap<String, Property>);
+pub struct Properties(HashMap<SmallString, Property>);
 
 pub(crate) type SharedProperties = Arc<Properties>;
 
@@ -18,7 +19,7 @@ impl Properties {
             let property = Property::new(offset, raw_property.kind);
             offset += raw_property.size;
             if property.kind != PropertyKind::Padding && property.kind != PropertyKind::VariantId {
-                properties.insert(raw_property.name.unwrap(), property);
+                properties.insert(raw_property.name, property);
             }
         }
         Properties(properties)
@@ -28,12 +29,12 @@ impl Properties {
         self.0.get(name.as_str())
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (&String, &Property)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&SmallString, &Property)> {
         self.0.iter()
     }
 
     #[cfg(test)]
-    pub fn inner(&self) -> &HashMap<String, Property> {
+    pub fn inner(&self) -> &HashMap<SmallString, Property> {
         &self.0
     }
 }

--- a/src/reader/directory_pack/lazy_entry.rs
+++ b/src/reader/directory_pack/lazy_entry.rs
@@ -48,7 +48,7 @@ impl EntryTrait for LazyEntry {
         }
     }
 
-    fn get_value(&self, name: &str) -> Result<Option<RawValue>> {
-        self._get_value(name)
+    fn get_value(&self, name: impl AsRef<str>) -> Result<Option<RawValue>> {
+        self._get_value(name.as_ref())
     }
 }

--- a/src/reader/directory_pack/mod.rs
+++ b/src/reader/directory_pack/mod.rs
@@ -24,7 +24,7 @@ pub use raw_value::RawValue;
 
 pub trait EntryTrait {
     fn get_variant_id(&self) -> Result<Option<VariantIdx>>;
-    fn get_value(&self, name: &str) -> Result<Option<RawValue>>;
+    fn get_value(&self, name: impl AsRef<str>) -> Result<Option<RawValue>>;
 }
 
 mod private {
@@ -127,7 +127,7 @@ impl DirectoryPack {
             let index_header = self
                 .reader
                 .parse_block_in::<IndexHeader>(sized_offset.offset, sized_offset.size)?;
-            if index_header.name == index_name {
+            if index_header.name.as_str() == index_name {
                 let index = Index::new(index_header);
                 return Ok(Some(index));
             }

--- a/src/reader/directory_pack/range.rs
+++ b/src/reader/directory_pack/range.rs
@@ -103,8 +103,8 @@ mod tests {
             fn get_variant_id(&self) -> Result<Option<VariantIdx>> {
                 Ok(None)
             }
-            fn get_value(&self, name: &str) -> Result<Option<RawValue>> {
-                if name == "foo" {
+            fn get_value(&self, name: impl AsRef<str>) -> Result<Option<RawValue>> {
+                if name.as_ref() == "foo" {
                     Ok(Some(self.v.clone()))
                 } else {
                     Ok(None)

--- a/src/reader/directory_pack/raw_layout.rs
+++ b/src/reader/directory_pack/raw_layout.rs
@@ -109,7 +109,7 @@ impl Parsable for RawProperty {
                         content_id_size: ByteSize::try_from(content_id_size as usize).unwrap(),
                         default_pack_id,
                     },
-                    Some(String::from_utf8(PString::parse(parser)?)?),
+                    Some(PString::parse(parser)?),
                 )
             }
             PropType::UnsignedInt | PropType::SignedInt => {
@@ -129,7 +129,7 @@ impl Parsable for RawProperty {
                                 default: Some(parser.read_isized(int_size)?),
                             }
                         },
-                        Some(String::from_utf8(PString::parse(parser)?)?),
+                        Some(PString::parse(parser)?),
                     )
                 } else {
                     (
@@ -145,7 +145,7 @@ impl Parsable for RawProperty {
                                 default: None,
                             }
                         },
-                        Some(String::from_utf8(PString::parse(parser)?)?),
+                        Some(PString::parse(parser)?),
                     )
                 }
             }
@@ -191,7 +191,7 @@ impl Parsable for RawProperty {
                                 default: Some((ASize::new(size as usize), fixed_data, key_id)),
                             }
                         },
-                        Some(String::from_utf8(PString::parse(parser)?)?),
+                        Some(PString::parse(parser)?),
                     )
                 } else {
                     (
@@ -206,15 +206,11 @@ impl Parsable for RawProperty {
                             deported_info,
                             default: None,
                         },
-                        Some(String::from_utf8(PString::parse(parser)?)?),
+                        Some(PString::parse(parser)?),
                     )
                 }
             }
-            PropType::VariantId => (
-                1,
-                PropertyKind::VariantId,
-                Some(String::from_utf8(PString::parse(parser)?)?),
-            ),
+            PropType::VariantId => (1, PropertyKind::VariantId, Some(PString::parse(parser)?)),
             PropType::DeportedUnsignedInt | PropType::DeportedSignedInt => {
                 let default_value = (propdata & 0b1000) != 0;
                 let int_size = ByteSize::try_from((propdata & 0x07) as usize + 1).unwrap();
@@ -238,7 +234,7 @@ impl Parsable for RawProperty {
                                 id: DeportedDefault::Value(key_value),
                             }
                         },
-                        Some(String::from_utf8(PString::parse(parser)?)?),
+                        Some(PString::parse(parser)?),
                     )
                 } else {
                     (
@@ -256,7 +252,7 @@ impl Parsable for RawProperty {
                                 id: DeportedDefault::KeySize(key_id_size),
                             }
                         },
-                        Some(String::from_utf8(PString::parse(parser)?)?),
+                        Some(PString::parse(parser)?),
                     )
                 }
             }

--- a/src/reader/directory_pack/raw_layout.rs
+++ b/src/reader/directory_pack/raw_layout.rs
@@ -65,14 +65,18 @@ pub(crate) enum PropertyKind {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct RawProperty {
     pub size: usize, // The size of the value stored in the entry.
-    pub name: Option<String>,
+    pub name: SmallString,
     pub kind: PropertyKind,
 }
 
 impl RawProperty {
     #[cfg(test)]
-    pub fn new(kind: PropertyKind, size: usize, name: Option<String>) -> Self {
-        Self { size, kind, name }
+    pub fn new(kind: PropertyKind, size: usize, name: impl Into<SmallString>) -> Self {
+        Self {
+            size,
+            kind,
+            name: name.into(),
+        }
     }
 
     pub fn is_variant_id(&self) -> bool {
@@ -87,7 +91,11 @@ impl Parsable for RawProperty {
         let proptype = PropType::try_from(propinfo & 0xF0)?;
         let propdata = propinfo & 0x0F;
         let (propsize, kind, name) = match proptype {
-            PropType::Padding => (propdata as u16 + 1, PropertyKind::Padding, None),
+            PropType::Padding => (
+                propdata as u16 + 1,
+                PropertyKind::Padding,
+                SmallString::default(),
+            ),
             PropType::ContentAddress => {
                 let pack_id_size =
                     ByteSize::try_from(((propdata & 0b0100) >> 2) as usize + 1).unwrap();
@@ -109,7 +117,7 @@ impl Parsable for RawProperty {
                         content_id_size: ByteSize::try_from(content_id_size as usize).unwrap(),
                         default_pack_id,
                     },
-                    Some(PString::parse(parser)?),
+                    PString::parse(parser)?,
                 )
             }
             PropType::UnsignedInt | PropType::SignedInt => {
@@ -129,7 +137,7 @@ impl Parsable for RawProperty {
                                 default: Some(parser.read_isized(int_size)?),
                             }
                         },
-                        Some(PString::parse(parser)?),
+                        PString::parse(parser)?,
                     )
                 } else {
                     (
@@ -145,7 +153,7 @@ impl Parsable for RawProperty {
                                 default: None,
                             }
                         },
-                        Some(PString::parse(parser)?),
+                        PString::parse(parser)?,
                     )
                 }
             }
@@ -191,7 +199,7 @@ impl Parsable for RawProperty {
                                 default: Some((ASize::new(size as usize), fixed_data, key_id)),
                             }
                         },
-                        Some(PString::parse(parser)?),
+                        PString::parse(parser)?,
                     )
                 } else {
                     (
@@ -206,11 +214,11 @@ impl Parsable for RawProperty {
                             deported_info,
                             default: None,
                         },
-                        Some(PString::parse(parser)?),
+                        PString::parse(parser)?,
                     )
                 }
             }
-            PropType::VariantId => (1, PropertyKind::VariantId, Some(PString::parse(parser)?)),
+            PropType::VariantId => (1, PropertyKind::VariantId, PString::parse(parser)?),
             PropType::DeportedUnsignedInt | PropType::DeportedSignedInt => {
                 let default_value = (propdata & 0b1000) != 0;
                 let int_size = ByteSize::try_from((propdata & 0x07) as usize + 1).unwrap();
@@ -234,7 +242,7 @@ impl Parsable for RawProperty {
                                 id: DeportedDefault::Value(key_value),
                             }
                         },
-                        Some(PString::parse(parser)?),
+                        PString::parse(parser)?,
                     )
                 } else {
                     (
@@ -252,7 +260,7 @@ impl Parsable for RawProperty {
                                 id: DeportedDefault::KeySize(key_id_size),
                             }
                         },
-                        Some(PString::parse(parser)?),
+                        PString::parse(parser)?,
                     )
                 }
             }
@@ -299,76 +307,76 @@ mod tests {
     use super::*;
     use test_case::test_case;
 
-    #[test_case(&[0b1000_0000, 1, b'a'] => RawProperty{size:1, kind:PropertyKind::VariantId, name: Some(String::from("a")) })]
-    #[test_case(&[0b0000_0000] => RawProperty{size:1, kind:PropertyKind::Padding, name: None })]
-    #[test_case(&[0b0000_0111] => RawProperty{size:8, kind:PropertyKind::Padding, name: None })]
-    #[test_case(&[0b0000_1111] => RawProperty{size:16, kind:PropertyKind::Padding, name: None })]
+    #[test_case(&[0b1000_0000, 1, b'a'] => RawProperty::new(PropertyKind::VariantId, 1, "a"))]
+    #[test_case(&[0b0000_0000] => RawProperty::new(PropertyKind::Padding, 1, ""))]
+    #[test_case(&[0b0000_0111] => RawProperty::new(PropertyKind::Padding, 8, ""))]
+    #[test_case(&[0b0000_1111] => RawProperty::new(PropertyKind::Padding, 16, ""))]
     // ContentAddress
-    #[test_case(&[0b0001_0000, 1, b'a'] => RawProperty{size:2, kind:PropertyKind::ContentAddress{pack_id_size: ByteSize::U1, content_id_size: ByteSize::U1, default_pack_id: None}, name: Some(String::from("a")) })]
-    #[test_case(&[0b0001_0001, 1, b'a'] => RawProperty{size:3, kind:PropertyKind::ContentAddress{pack_id_size: ByteSize::U1, content_id_size: ByteSize::U2, default_pack_id: None}, name: Some(String::from("a")) })]
-    #[test_case(&[0b0001_0110, 1, b'a'] => RawProperty{size:5, kind:PropertyKind::ContentAddress{pack_id_size: ByteSize::U2, content_id_size: ByteSize::U3, default_pack_id: None}, name: Some(String::from("a")) })]
+    #[test_case(&[0b0001_0000, 1, b'a'] => RawProperty::new(PropertyKind::ContentAddress{pack_id_size: ByteSize::U1, content_id_size: ByteSize::U1, default_pack_id: None}, 2, "a"))]
+    #[test_case(&[0b0001_0001, 1, b'a'] => RawProperty::new(PropertyKind::ContentAddress{pack_id_size: ByteSize::U1, content_id_size: ByteSize::U2, default_pack_id: None}, 3, "a"))]
+    #[test_case(&[0b0001_0110, 1, b'a'] => RawProperty::new(PropertyKind::ContentAddress{pack_id_size: ByteSize::U2, content_id_size: ByteSize::U3, default_pack_id: None}, 5, "a"))]
     // ContentAddress with default pack_id
-    #[test_case(&[0b0001_1000, 0x01, 1, b'a'] => RawProperty{size:1, kind:PropertyKind::ContentAddress{pack_id_size: ByteSize::U1, content_id_size: ByteSize::U1, default_pack_id: Some(1.into())}, name: Some(String::from("a")) })]
-    #[test_case(&[0b0001_1001, 0x01, 1, b'a'] => RawProperty{size:2, kind:PropertyKind::ContentAddress{pack_id_size: ByteSize::U1, content_id_size: ByteSize::U2, default_pack_id: Some(1.into())}, name: Some(String::from("a")) })]
-    #[test_case(&[0b0001_1110, 0x01, 0x02, 1, b'a'] => RawProperty{size:3, kind:PropertyKind::ContentAddress{pack_id_size: ByteSize::U2, content_id_size: ByteSize::U3, default_pack_id: Some(0x0201.into())}, name: Some(String::from("a")) })]
+    #[test_case(&[0b0001_1000, 0x01, 1, b'a'] => RawProperty::new(PropertyKind::ContentAddress{pack_id_size: ByteSize::U1, content_id_size: ByteSize::U1, default_pack_id: Some(1.into())},1, "a"))]
+    #[test_case(&[0b0001_1001, 0x01, 1, b'a'] => RawProperty::new(PropertyKind::ContentAddress{pack_id_size: ByteSize::U1, content_id_size: ByteSize::U2, default_pack_id: Some(1.into())}, 2, "a"))]
+    #[test_case(&[0b0001_1110, 0x01, 0x02, 1, b'a'] => RawProperty::new(PropertyKind::ContentAddress{pack_id_size: ByteSize::U2, content_id_size: ByteSize::U3, default_pack_id: Some(0x0201.into())}, 3, "a"))]
     // Plain integer
-    #[test_case(&[0b0010_0000, 1, b'a'] => RawProperty{size:1, kind:PropertyKind::UnsignedInt{int_size: ByteSize::U1, default: None}, name: Some(String::from("a")) })]
-    #[test_case(&[0b0010_0010, 1, b'a'] => RawProperty{size:3, kind:PropertyKind::UnsignedInt{int_size: ByteSize::U3, default: None}, name: Some(String::from("a")) })]
-    #[test_case(&[0b0010_0111, 1, b'a'] => RawProperty{size:8, kind:PropertyKind::UnsignedInt{int_size: ByteSize::U8, default: None}, name: Some(String::from("a")) })]
-    #[test_case(&[0b0011_0000, 1, b'a'] => RawProperty{size:1, kind:PropertyKind::SignedInt{int_size: ByteSize::U1, default: None}, name: Some(String::from("a")) })]
-    #[test_case(&[0b0011_0010, 1, b'a'] => RawProperty{size:3, kind:PropertyKind::SignedInt{int_size: ByteSize::U3, default: None}, name: Some(String::from("a")) })]
-    #[test_case(&[0b0011_0111, 1, b'a'] => RawProperty{size:8, kind:PropertyKind::SignedInt{int_size: ByteSize::U8, default: None}, name: Some(String::from("a")) })]
+    #[test_case(&[0b0010_0000, 1, b'a'] => RawProperty::new(PropertyKind::UnsignedInt{int_size: ByteSize::U1, default: None}, 1, "a"))]
+    #[test_case(&[0b0010_0010, 1, b'a'] => RawProperty::new(PropertyKind::UnsignedInt{int_size: ByteSize::U3, default: None}, 3, "a"))]
+    #[test_case(&[0b0010_0111, 1, b'a'] => RawProperty::new(PropertyKind::UnsignedInt{int_size: ByteSize::U8, default: None}, 8, "a"))]
+    #[test_case(&[0b0011_0000, 1, b'a'] => RawProperty::new(PropertyKind::SignedInt{int_size: ByteSize::U1, default: None}, 1, "a"))]
+    #[test_case(&[0b0011_0010, 1, b'a'] => RawProperty::new(PropertyKind::SignedInt{int_size: ByteSize::U3, default: None}, 3, "a"))]
+    #[test_case(&[0b0011_0111, 1, b'a'] => RawProperty::new(PropertyKind::SignedInt{int_size: ByteSize::U8, default: None}, 8, "a"))]
     // Plain integer with default value
-    #[test_case(&[0b0010_1000, 0xff, 1, b'a'] => RawProperty{size:0, kind:PropertyKind::UnsignedInt{int_size: ByteSize::U1, default: Some(0xff)}, name: Some(String::from("a")) })]
-    #[test_case(&[0b0010_1010, 0x03, 0x02, 0x01, 1, b'a'] => RawProperty{size:0, kind:PropertyKind::UnsignedInt{int_size: ByteSize::U3, default: Some(0x010203)}, name: Some(String::from("a")) })]
-    #[test_case(&[0b0010_1111, 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 1, b'a'] => RawProperty{size:0, kind:PropertyKind::UnsignedInt{int_size: ByteSize::U8, default: Some(0x0102030405060708)}, name: Some(String::from("a")) })]
-    #[test_case(&[0b0011_1000, 0xff, 1, b'a'] => RawProperty{size:0, kind:PropertyKind::SignedInt{int_size: ByteSize::U1, default: Some(-1_i64)}, name: Some(String::from("a")) })]
-    #[test_case(&[0b0011_1010, 0x03, 0x02, 0x01, 1, b'a'] => RawProperty{size:0, kind:PropertyKind::SignedInt{int_size: ByteSize::U3, default: Some(0x010203_i64)}, name: Some(String::from("a")) })]
-    #[test_case(&[0b0011_1111, 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 1, b'a'] => RawProperty{size:0, kind:PropertyKind::SignedInt{int_size: ByteSize::U8, default: Some(0x0102030405060708_i64)}, name: Some(String::from("a")) })]
+    #[test_case(&[0b0010_1000, 0xff, 1, b'a'] => RawProperty::new(PropertyKind::UnsignedInt{int_size: ByteSize::U1, default: Some(0xff)}, 0, "a"))]
+    #[test_case(&[0b0010_1010, 0x03, 0x02, 0x01, 1, b'a'] => RawProperty::new(PropertyKind::UnsignedInt{int_size: ByteSize::U3, default: Some(0x010203)}, 0, "a"))]
+    #[test_case(&[0b0010_1111, 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 1, b'a'] => RawProperty::new(PropertyKind::UnsignedInt{int_size: ByteSize::U8, default: Some(0x0102030405060708)}, 0, "a"))]
+    #[test_case(&[0b0011_1000, 0xff, 1, b'a'] => RawProperty::new(PropertyKind::SignedInt{int_size: ByteSize::U1, default: Some(-1_i64)}, 0, "a"))]
+    #[test_case(&[0b0011_1010, 0x03, 0x02, 0x01, 1, b'a'] => RawProperty::new(PropertyKind::SignedInt{int_size: ByteSize::U3, default: Some(0x010203_i64)}, 0, "a"))]
+    #[test_case(&[0b0011_1111, 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 1, b'a'] => RawProperty::new(PropertyKind::SignedInt{int_size: ByteSize::U8, default: Some(0x0102030405060708_i64)}, 0, "a"))]
     // Deported integer
-    #[test_case(&[0b1010_0000, 0b0000_0000, 0xff, 1, b'a'] => RawProperty{size:1, kind:PropertyKind::DeportedUnsignedInt{int_size: ByteSize::U1, value_store_idx: 0xff.into(), id: DeportedDefault::KeySize(ByteSize::U1)}, name: Some(String::from("a")) })]
-    #[test_case(&[0b1010_0010, 0b0000_0001, 0xff, 1, b'a'] => RawProperty{size:2, kind:PropertyKind::DeportedUnsignedInt{int_size: ByteSize::U3, value_store_idx: 0xff.into(), id: DeportedDefault::KeySize(ByteSize::U2)}, name: Some(String::from("a")) })]
-    #[test_case(&[0b1010_0111, 0b0000_0111, 0xff, 1, b'a'] => RawProperty{size:8, kind:PropertyKind::DeportedUnsignedInt{int_size: ByteSize::U8, value_store_idx: 0xff.into(), id: DeportedDefault::KeySize(ByteSize::U8)}, name: Some(String::from("a")) })]
-    #[test_case(&[0b1011_0000, 0b0000_0111, 0xff, 1, b'a'] => RawProperty{size:8, kind:PropertyKind::DeportedSignedInt{int_size: ByteSize::U1, value_store_idx: 0xff.into(), id: DeportedDefault::KeySize(ByteSize::U8)}, name: Some(String::from("a")) })]
-    #[test_case(&[0b1011_0010, 0b0000_0001, 0xff, 1, b'a'] => RawProperty{size:2, kind:PropertyKind::DeportedSignedInt{int_size: ByteSize::U3, value_store_idx: 0xff.into(), id: DeportedDefault::KeySize(ByteSize::U2)}, name: Some(String::from("a")) })]
-    #[test_case(&[0b1011_0111, 0b0000_0010, 0xff, 1, b'a'] => RawProperty{size:3, kind:PropertyKind::DeportedSignedInt{int_size: ByteSize::U8, value_store_idx: 0xff.into(), id: DeportedDefault::KeySize(ByteSize::U3)}, name: Some(String::from("a")) })]
+    #[test_case(&[0b1010_0000, 0b0000_0000, 0xff, 1, b'a'] => RawProperty::new(PropertyKind::DeportedUnsignedInt{int_size: ByteSize::U1, value_store_idx: 0xff.into(), id: DeportedDefault::KeySize(ByteSize::U1)}, 1, "a"))]
+    #[test_case(&[0b1010_0010, 0b0000_0001, 0xff, 1, b'a'] => RawProperty::new(PropertyKind::DeportedUnsignedInt{int_size: ByteSize::U3, value_store_idx: 0xff.into(), id: DeportedDefault::KeySize(ByteSize::U2)}, 2, "a"))]
+    #[test_case(&[0b1010_0111, 0b0000_0111, 0xff, 1, b'a'] => RawProperty::new(PropertyKind::DeportedUnsignedInt{int_size: ByteSize::U8, value_store_idx: 0xff.into(), id: DeportedDefault::KeySize(ByteSize::U8)}, 8, "a"))]
+    #[test_case(&[0b1011_0000, 0b0000_0111, 0xff, 1, b'a'] => RawProperty::new(PropertyKind::DeportedSignedInt{int_size: ByteSize::U1, value_store_idx: 0xff.into(), id: DeportedDefault::KeySize(ByteSize::U8)}, 8, "a"))]
+    #[test_case(&[0b1011_0010, 0b0000_0001, 0xff, 1, b'a'] => RawProperty::new(PropertyKind::DeportedSignedInt{int_size: ByteSize::U3, value_store_idx: 0xff.into(), id: DeportedDefault::KeySize(ByteSize::U2)}, 2, "a"))]
+    #[test_case(&[0b1011_0111, 0b0000_0010, 0xff, 1, b'a'] => RawProperty::new(PropertyKind::DeportedSignedInt{int_size: ByteSize::U8, value_store_idx: 0xff.into(), id: DeportedDefault::KeySize(ByteSize::U3)}, 3, "a"))]
     // Deported integer with default index
-    #[test_case(&[0b1010_1000, 0b0000_0000, 0xff, 0xff, 1, b'a'] => RawProperty{size:0, kind:PropertyKind::DeportedUnsignedInt{int_size: ByteSize::U1, value_store_idx: 0xff.into(), id: DeportedDefault::Value(0xff_u64)}, name: Some(String::from("a")) })]
-    #[test_case(&[0b1010_1010, 0b0000_0001, 0xff, 0xfe, 0xff, 1, b'a'] => RawProperty{size:0, kind:PropertyKind::DeportedUnsignedInt{int_size: ByteSize::U3, value_store_idx: 0xff.into(), id: DeportedDefault::Value(0xfffe_u64)}, name: Some(String::from("a")) })]
-    #[test_case(&[0b1010_1111, 0b0000_0010, 0xff, 0x03, 0x02, 0x01, 1, b'a'] => RawProperty{size:0, kind:PropertyKind::DeportedUnsignedInt{int_size: ByteSize::U8, value_store_idx: 0xff.into(), id: DeportedDefault::Value(0x010203_u64)}, name: Some(String::from("a")) })]
-    #[test_case(&[0b1011_1000, 0b0000_0011, 0xff, 0xff, 0xff, 0xff, 0xff, 1, b'a'] => RawProperty{size:0, kind:PropertyKind::DeportedSignedInt{int_size: ByteSize::U1, value_store_idx: 0xff.into(), id: DeportedDefault::Value(0xffffffff_u64)}, name: Some(String::from("a")) })]
-    #[test_case(&[0b1011_1010, 0b0000_0001, 0xff, 0xff, 0xff, 1, b'a'] => RawProperty{size:0, kind:PropertyKind::DeportedSignedInt{int_size: ByteSize::U3, value_store_idx: 0xff.into(), id: DeportedDefault::Value(0xffff_u64)}, name: Some(String::from("a")) })]
-    #[test_case(&[0b1011_1111, 0b0000_0010, 0xff, 0xff, 0xff, 0xff, 1, b'a'] => RawProperty{size:0, kind:PropertyKind::DeportedSignedInt{int_size: ByteSize::U8, value_store_idx: 0xff.into(), id: DeportedDefault::Value(0xffffff_u64)}, name: Some(String::from("a")) })]
+    #[test_case(&[0b1010_1000, 0b0000_0000, 0xff, 0xff, 1, b'a'] => RawProperty::new(PropertyKind::DeportedUnsignedInt{int_size: ByteSize::U1, value_store_idx: 0xff.into(), id: DeportedDefault::Value(0xff_u64)}, 0, "a"))]
+    #[test_case(&[0b1010_1010, 0b0000_0001, 0xff, 0xfe, 0xff, 1, b'a'] => RawProperty::new(PropertyKind::DeportedUnsignedInt{int_size: ByteSize::U3, value_store_idx: 0xff.into(), id: DeportedDefault::Value(0xfffe_u64)}, 0, "a"))]
+    #[test_case(&[0b1010_1111, 0b0000_0010, 0xff, 0x03, 0x02, 0x01, 1, b'a'] => RawProperty::new(PropertyKind::DeportedUnsignedInt{int_size: ByteSize::U8, value_store_idx: 0xff.into(), id: DeportedDefault::Value(0x010203_u64)}, 0, "a"))]
+    #[test_case(&[0b1011_1000, 0b0000_0011, 0xff, 0xff, 0xff, 0xff, 0xff, 1, b'a'] => RawProperty::new(PropertyKind::DeportedSignedInt{int_size: ByteSize::U1, value_store_idx: 0xff.into(), id: DeportedDefault::Value(0xffffffff_u64)}, 0, "a"))]
+    #[test_case(&[0b1011_1010, 0b0000_0001, 0xff, 0xff, 0xff, 1, b'a'] => RawProperty::new(PropertyKind::DeportedSignedInt{int_size: ByteSize::U3, value_store_idx: 0xff.into(), id: DeportedDefault::Value(0xffff_u64)}, 0, "a"))]
+    #[test_case(&[0b1011_1111, 0b0000_0010, 0xff, 0xff, 0xff, 0xff, 1, b'a'] => RawProperty::new(PropertyKind::DeportedSignedInt{int_size: ByteSize::U8, value_store_idx: 0xff.into(), id: DeportedDefault::Value(0xffffff_u64)},0 , "a"))]
     // Char[] without deported part :
-    #[test_case(&[0b0101_0001, 0b000_00000, 1, b'a'] => RawProperty{size:1+0+0, kind:PropertyKind::Array{array_len_size: Some(ByteSize::U1), fixed_array_len: 0, deported_info: None, default: None}, name: Some(String::from("a")) })]
-    #[test_case(&[0b0101_0001, 0b000_00001, 1, b'a'] => RawProperty{size:1+1+0, kind:PropertyKind::Array{array_len_size: Some(ByteSize::U1), fixed_array_len: 1, deported_info: None, default: None}, name: Some(String::from("a")) })]
-    #[test_case(&[0b0101_0011, 0b000_00101, 1, b'a'] => RawProperty{size:3+5+0, kind:PropertyKind::Array{array_len_size: Some(ByteSize::U3), fixed_array_len: 5, deported_info: None, default: None}, name: Some(String::from("a")) })]
-    #[test_case(&[0b0101_0011, 0b000_11111, 1, b'a'] => RawProperty{size:3+31+0, kind:PropertyKind::Array{array_len_size: Some(ByteSize::U3), fixed_array_len: 31, deported_info: None, default: None}, name: Some(String::from("a")) })]
+    #[test_case(&[0b0101_0001, 0b000_00000, 1, b'a'] => RawProperty::new(PropertyKind::Array{array_len_size: Some(ByteSize::U1), fixed_array_len: 0, deported_info: None, default: None}, 1+0+0, "a"))]
+    #[test_case(&[0b0101_0001, 0b000_00001, 1, b'a'] => RawProperty::new(PropertyKind::Array{array_len_size: Some(ByteSize::U1), fixed_array_len: 1, deported_info: None, default: None}, 1+1+0, "a"))]
+    #[test_case(&[0b0101_0011, 0b000_00101, 1, b'a'] => RawProperty::new(PropertyKind::Array{array_len_size: Some(ByteSize::U3), fixed_array_len: 5, deported_info: None, default: None}, 3+5+0, "a"))]
+    #[test_case(&[0b0101_0011, 0b000_11111, 1, b'a'] => RawProperty::new(PropertyKind::Array{array_len_size: Some(ByteSize::U3), fixed_array_len: 31, deported_info: None, default: None}, 3+31+0, "a"))]
     // Char[] without deported part and with default value:
-    #[test_case(&[0b0101_1001, 0b000_00000, 0x00, 1, b'a'] => RawProperty{size:0, kind:PropertyKind::Array{array_len_size: Some(ByteSize::U1), fixed_array_len: 0, deported_info: None, default: Some((0.into(), BaseArray::default(), None))}, name: Some(String::from("a")) })]
-    #[test_case(&[0b0101_1001, 0b000_00001, 0x01, b'a', 1, b'a'] => RawProperty{size:0, kind:PropertyKind::Array{array_len_size: Some(ByteSize::U1), fixed_array_len: 1, deported_info: None, default: Some((1.into(), BaseArray::new(b"a"), None))}, name: Some(String::from("a")) })]
-    #[test_case(&[0b0101_1011, 0b000_00101, 0x04, 0x00, 0x00, b'a', b'b', b'c', b'd', b'\0', 1, b'a'] => RawProperty{size:0, kind:PropertyKind::Array{array_len_size: Some(ByteSize::U3), fixed_array_len: 5, deported_info: None, default: Some((4.into(), BaseArray::new(b"abcd"), None))}, name: Some(String::from("a")) })]
+    #[test_case(&[0b0101_1001, 0b000_00000, 0x00, 1, b'a'] => RawProperty::new(PropertyKind::Array{array_len_size: Some(ByteSize::U1), fixed_array_len: 0, deported_info: None, default: Some((0.into(), BaseArray::default(), None))}, 0, "a"))]
+    #[test_case(&[0b0101_1001, 0b000_00001, 0x01, b'a', 1, b'a'] => RawProperty::new(PropertyKind::Array{array_len_size: Some(ByteSize::U1), fixed_array_len: 1, deported_info: None, default: Some((1.into(), BaseArray::new(b"a"), None))}, 0, "a"))]
+    #[test_case(&[0b0101_1011, 0b000_00101, 0x04, 0x00, 0x00, b'a', b'b', b'c', b'd', b'\0', 1, b'a'] => RawProperty::new(PropertyKind::Array{array_len_size: Some(ByteSize::U3), fixed_array_len: 5, deported_info: None, default: Some((4.into(), BaseArray::new(b"abcd"), None))}, 0, "a"))]
     #[test_case(&[0b0101_1001, 0b000_11111,
       0x1A,
       b'a', b'b', b'c', b'd', b'e', b'f', b'g', b'h', b'i', b'j', b'k', b'l', b'm', b'n', b'o', b'p', b'q', b'r', b's', b't', b'u', b'v', b'w', b'x', b'y', b'z', 0x00, 0x00, 0x00, 0x00, 0x00, 1, b'a' ] =>
-      RawProperty{size:0, kind:PropertyKind::Array{array_len_size: Some(ByteSize::U1), fixed_array_len: 31, deported_info: None, default: Some((26.into(), BaseArray::new(b"abcdefghijklmnopqrstuvwxyz"), None))}, name: Some(String::from("a")) })]
+      RawProperty::new(PropertyKind::Array{array_len_size: Some(ByteSize::U1), fixed_array_len: 31, deported_info: None, default: Some((26.into(), BaseArray::new(b"abcdefghijklmnopqrstuvwxyz"), None))}, 0, "a"))]
     // Char[] with deported part :
-    #[test_case(&[0b0101_0001, 0b001_00000, 0x0F, 1, b'a'] => RawProperty{size:1+0+1, kind:PropertyKind::Array{array_len_size: Some(ByteSize::U1), fixed_array_len: 0, deported_info: Some(DeportedInfo{ id_size: ByteSize::U1, value_store_idx: ValueStoreIdx::from(0x0F)}), default: None}, name: Some(String::from("a")) })]
-    #[test_case(&[0b0101_0001, 0b010_00001, 0x0F, 1, b'a'] => RawProperty{size:1+1+2, kind:PropertyKind::Array{array_len_size: Some(ByteSize::U1), fixed_array_len: 1, deported_info: Some(DeportedInfo{ id_size: ByteSize::U2, value_store_idx: ValueStoreIdx::from(0x0F)}), default: None}, name: Some(String::from("a")) })]
-    #[test_case(&[0b0101_0011, 0b100_00101, 0x0F, 1, b'a'] => RawProperty{size:3+5+4, kind:PropertyKind::Array{array_len_size: Some(ByteSize::U3), fixed_array_len: 5, deported_info: Some(DeportedInfo{ id_size: ByteSize::U4, value_store_idx: ValueStoreIdx::from(0x0F)}), default: None}, name: Some(String::from("a")) })]
-    #[test_case(&[0b0101_0011, 0b100_11111, 0x0F, 1, b'a'] => RawProperty{size:3+31+4, kind:PropertyKind::Array{array_len_size: Some(ByteSize::U3), fixed_array_len: 31, deported_info: Some(DeportedInfo{ id_size: ByteSize::U4, value_store_idx: ValueStoreIdx::from(0x0F)}), default: None}, name: Some(String::from("a")) })]
+    #[test_case(&[0b0101_0001, 0b001_00000, 0x0F, 1, b'a'] => RawProperty::new(PropertyKind::Array{array_len_size: Some(ByteSize::U1), fixed_array_len: 0, deported_info: Some(DeportedInfo{ id_size: ByteSize::U1, value_store_idx: ValueStoreIdx::from(0x0F)}), default: None}, 1+0+1, "a"))]
+    #[test_case(&[0b0101_0001, 0b010_00001, 0x0F, 1, b'a'] => RawProperty::new(PropertyKind::Array{array_len_size: Some(ByteSize::U1), fixed_array_len: 1, deported_info: Some(DeportedInfo{ id_size: ByteSize::U2, value_store_idx: ValueStoreIdx::from(0x0F)}), default: None}, 1+1+2, "a"))]
+    #[test_case(&[0b0101_0011, 0b100_00101, 0x0F, 1, b'a'] => RawProperty::new(PropertyKind::Array{array_len_size: Some(ByteSize::U3), fixed_array_len: 5, deported_info: Some(DeportedInfo{ id_size: ByteSize::U4, value_store_idx: ValueStoreIdx::from(0x0F)}), default: None}, 3+5+4, "a"))]
+    #[test_case(&[0b0101_0011, 0b100_11111, 0x0F, 1, b'a'] => RawProperty::new(PropertyKind::Array{array_len_size: Some(ByteSize::U3), fixed_array_len: 31, deported_info: Some(DeportedInfo{ id_size: ByteSize::U4, value_store_idx: ValueStoreIdx::from(0x0F)}), default: None}, 3+31+4, "a"))]
     // Char[] without deported part and with default value:
     #[test_case(&[0b0101_1001, 0b001_00000, 0x0F, 0x00, 0x50, 1, b'a']
-      => RawProperty{size:0, kind:PropertyKind::Array{array_len_size: Some(ByteSize::U1), fixed_array_len: 0, deported_info: Some(DeportedInfo{ id_size: ByteSize::U1, value_store_idx: ValueStoreIdx::from(0x0F)}), default: Some((0.into(), BaseArray::default(), Some(0x50)))}, name: Some(String::from("a")) })]
+      => RawProperty::new(PropertyKind::Array{array_len_size: Some(ByteSize::U1), fixed_array_len: 0, deported_info: Some(DeportedInfo{ id_size: ByteSize::U1, value_store_idx: ValueStoreIdx::from(0x0F)}), default: Some((0.into(), BaseArray::default(), Some(0x50)))}, 0, "a"))]
     #[test_case(&[0b0101_1001, 0b010_00001, 0x0F, 0x10, b'a', 0x50, 0x00, 1, b'a']
-      => RawProperty{size:0, kind:PropertyKind::Array{array_len_size: Some(ByteSize::U1), fixed_array_len: 1, deported_info: Some(DeportedInfo{ id_size: ByteSize::U2, value_store_idx: ValueStoreIdx::from(0x0F)}), default: Some((16.into(), BaseArray::new(b"a"), Some(0x50)))}, name: Some(String::from("a")) })]
+      => RawProperty::new(PropertyKind::Array{array_len_size: Some(ByteSize::U1), fixed_array_len: 1, deported_info: Some(DeportedInfo{ id_size: ByteSize::U2, value_store_idx: ValueStoreIdx::from(0x0F)}), default: Some((16.into(), BaseArray::new(b"a"), Some(0x50)))}, 0, "a"))]
     #[test_case(&[0b0101_1011, 0b100_00101, 0x0F, 0x04, 0x00, 0x00, b'a', b'b', b'c', b'd', b'\0', 0xfc, 0xfd, 0xfe, 0xff, 1, b'a']
-      => RawProperty{size:0, kind:PropertyKind::Array{array_len_size: Some(ByteSize::U3), fixed_array_len: 5, deported_info: Some(DeportedInfo{ id_size: ByteSize::U4, value_store_idx: ValueStoreIdx::from(0x0F)}), default: Some((4.into(), BaseArray::new(b"abcd"), Some(0xfffefdfc)))}, name: Some(String::from("a")) })]
+      => RawProperty::new(PropertyKind::Array{array_len_size: Some(ByteSize::U3), fixed_array_len: 5, deported_info: Some(DeportedInfo{ id_size: ByteSize::U4, value_store_idx: ValueStoreIdx::from(0x0F)}), default: Some((4.into(), BaseArray::new(b"abcd"), Some(0xfffefdfc)))}, 0, "a"))]
     #[test_case(&[0b0101_1011, 0b100_11111, 0x0F,
       0x03, 0x02, 0x01,
       b'a', b'b', b'c', b'd', b'e', b'f', b'g', b'h', b'i', b'j', b'k', b'l', b'm', b'n', b'o', b'p', b'q', b'r', b's', b't', b'u', b'v', b'w', b'x', b'y', b'z', 0x00, 0x00, 0x00, 0x00, 0x00,
       0xfc, 0xfd, 0xfe, 0xff, 1, b'a' ]
-       => RawProperty{size:0, kind:PropertyKind::Array{array_len_size: Some(ByteSize::U3), fixed_array_len: 31, deported_info: Some(DeportedInfo{ id_size: ByteSize::U4, value_store_idx: ValueStoreIdx::from(0x0F)}), default: Some((0x010203.into(), BaseArray::new(b"abcdefghijklmnopqrstuvwxyz"), Some(0xfffefdfc)))}, name: Some(String::from("a")) })]
+       => RawProperty::new(PropertyKind::Array{array_len_size: Some(ByteSize::U3), fixed_array_len: 31, deported_info: Some(DeportedInfo{ id_size: ByteSize::U4, value_store_idx: ValueStoreIdx::from(0x0F)}), default: Some((0x010203.into(), BaseArray::new(b"abcdefghijklmnopqrstuvwxyz"), Some(0xfffefdfc)))}, 0, "a"))]
 
     fn test_rawproperty(source: &[u8]) -> RawProperty {
         let mut content = Vec::new();

--- a/src/reader/directory_pack/raw_value.rs
+++ b/src/reader/directory_pack/raw_value.rs
@@ -53,7 +53,7 @@ impl Array {
         }
     }
 
-    pub fn resolve_to_vec(&self, vec: &mut Vec<u8>) -> Result<()> {
+    pub fn resolve_to_vec(&self, vec: &mut SmallBytes) -> Result<()> {
         let our_iter = ArrayIter::new(self)?;
         if let Some(s) = self.size {
             vec.reserve(s.into_u64() as usize);
@@ -208,16 +208,16 @@ impl RawValue {
             RawValue::I32(v) => Value::Signed(*v as i64),
             RawValue::I64(v) => Value::Signed(*v),
             RawValue::Array(a) => {
-                let mut vec = vec![];
+                let mut vec = SmallBytes::new();
                 a.resolve_to_vec(&mut vec)?;
                 Value::Array(vec)
             }
         })
     }
 
-    pub fn as_vec(&self) -> Result<Vec<u8>> {
+    pub fn as_vec(&self) -> Result<SmallBytes> {
         if let RawValue::Array(a) = self {
-            let mut vec = vec![];
+            let mut vec = SmallBytes::new();
             a.resolve_to_vec(&mut vec)?;
             Ok(vec)
         } else {
@@ -374,10 +374,10 @@ mod tests {
             );
         }
 
-        fixture indirect_value(base: Vec<u8>, extend:Option<Extend>, expected: Vec<u8>) -> RawValue {
+        fixture indirect_value(base: Vec<u8>, extend:Option<Extend>, expected: SmallBytes) -> RawValue {
             params {
                 vec![
-                    (vec![], None, vec![]),
+                    (vec![], None, SmallBytes::new()),
                     ("Hello".into(), None, "Hello".into()),
                     ("Hello".into(), Some(Extend{store:Arc::new(mock::ValueStore{}), value_id:ValueIdx::from(0)}), "HelloHello".into()),
                     ("Hello ".into(), Some(Extend{store:Arc::new(mock::ValueStore{}), value_id:ValueIdx::from(10)}), "Hello Jubako".into()),

--- a/tests/creator_jubako.rs
+++ b/tests/creator_jubako.rs
@@ -108,7 +108,7 @@ test_suite! {
         let mut entry_store = Box::new(creator::EntryStore::new(entry_def, None));
         for (idx, entry) in entries.iter().enumerate() {
             entry_store.add_entry(creator::BasicEntry::new_from_schema(&entry_store.schema, None, HashMap::from([
-                ("V0", jubako::Value::Array(entry.path.clone().into())),
+                ("V0", jubako::Value::Array(entry.path.as_bytes().into())),
                 ("V1", jubako::Value::Content(jubako::ContentAddress::new(1.into(), (idx as u32).into()))),
                 ("V2", jubako::Value::Unsigned(entry.word_count as u64))
             ])));


### PR DESCRIPTION
SmallVec is a nice way to store small bytes array directly on stack without consuming more memory or extra allocation.